### PR TITLE
Added srna service and bug solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes in this project will be documented in this file
 
-### [0.4.2]() - 2021-06-01
+### [0.4.2](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.2) - 2021-06-01
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes in this project will be documented in this file
 
-### [0.4.2](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.2) - 2021-06-01
+## [0.5.0](https://github.com/regulondbunam/GraphQL-api/releases) - 2021-06-11
+
+### Added
+
+- SRNA Service was added in its first version of datamart as a Data Open Service in RegulonDB GraphQL Web Services. 
+  - Some of this missing fields was:
+    - Sigmulon - allCitations
+    - Regulon - statistics
+    - Operon - transcriptionUnits.promoters.boxes 
+
+### Fixed
+
+- Some bugs related to Regulon and Sigmulon services that cause missing fields on response were solved.
+
+---
+
+## [0.4.2](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.2) - 2021-06-01
 
 ### Fixed
 
@@ -14,13 +30,13 @@ All notable changes in this project will be documented in this file
 
 - A new version of Phrases Service was applied, this version is also available right now
 
-### [0.4.1](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.1) - 2021-05-27
+## [0.4.1](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.1) - 2021-05-27
 
 ### Fixed
 
 - A bug related to Operon Service in Transcription Units -> Terminators were this fields resolve a null response has been solved
 
-### [0.4.0](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.0) - 2021-05-18
+## [0.4.0](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.4.0) - 2021-05-18
 
 ### Updated
 
@@ -32,7 +48,9 @@ All notable changes in this project will be documented in this file
 - Sigmulon Service was added with its recently version of datamart as a Data Open Service in RegulonDB GraphQL Web Services. 
 - Added a first version of HT Service as a Data Open Service (this can be changed later)
 
-### [0.3.0](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.3.0) - 2021-04-20
+---
+
+## [0.3.0](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.3.0) - 2021-04-20
 
 ### Updated
 
@@ -42,7 +60,9 @@ All notable changes in this project will be documented in this file
 
 - Regulon Service was added with its recently version of datamart as a Data Open Service in RegulonDB GraphQL Web Services. 
 
-### [0.2.1]([Release RegulonDB-WS-API 0.2.1 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.2.1)) - 2021-03-11
+---
+
+## [0.2.1]([Release RegulonDB-WS-API 0.2.1 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.2.1)) - 2021-03-11
 
 ### Updated
 
@@ -51,9 +71,7 @@ All notable changes in this project will be documented in this file
   - regulatorBindingSites on transcriptionUnits.genes was updated to support regulatoryInteractions regulated by sRNA's.
   - mechanism property now appears on regulatorBindingSites Object
 
-
-
-### [0.2.0]([Release RegulonDB-WS-API 0.2.0 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.2.0)) - 2021-03-04
+## [0.2.0]([Release RegulonDB-WS-API 0.2.0 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.2.0)) - 2021-03-04
 
 ### Added
 
@@ -65,15 +83,15 @@ All notable changes in this project will be documented in this file
 
 - In Gene Datamart was added fragments object property in Gene Type for genes with multiple positions.
 
-### [0.1.1]([Release RegulonDB-WS-API 0.1.1 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.1.1)) - 2021-02-19
+---
+
+## [0.1.1]([Release RegulonDB-WS-API 0.1.1 · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.1.1)) - 2021-02-19
 
 ### Fixed
 
 - The mongodb connection file was updated to solve connection problems.
 
-
-
-### [0.1.0]([Release RegulonDB-WS-API-Federation · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.1.0)) - 2021-02-11
+## [0.1.0]([Release RegulonDB-WS-API-Federation · regulondbunam/GraphQL-api (github.com)](https://github.com/regulondbunam/GraphQL-api/releases/tag/0.1.0)) - 2021-02-11
 
 ### Added
 

--- a/build/config/playground_Options.js
+++ b/build/config/playground_Options.js
@@ -7,8 +7,8 @@ const playgroundTabs = exports.playgroundTabs = {
   tabs: [{
     endpoint: 'graphql',
     name: 'updates',
-    query: `# 10/05/2021
-# Added a first version of Sigmulon Service,
+    query: `# 11/06/2021
+# Added a first version of SRNA Service,
 # This version is for an upcoming release of RegulonDB GraphQL Web Services
 # In case of error or report a bug please contact us
 
@@ -17,22 +17,28 @@ const playgroundTabs = exports.playgroundTabs = {
 # Select query, see "docs" tab to get description about 
 # parameters and description
 
-  getSigmulonBy(search:"fliA or \\\"Sigma 70\\\""){
+  getSrnaBy(search:"dicF"){
     data{
       _id
-      sigmaFactor{
+      product{
         name
         gene{
-        	name
+          _id
+          name
+          strand
         }
-    	}
-      transcribedPromoters{s
-        operon_id
-        _id
-        name
-        boxes{
+      }
+      regulatoryInteractions{
+        mechanism
+        regulatedEntity{
+          name
+          type
+        }
+        distanceToGene
+        regulatoryBindingSites{
           leftEndPosition
           rightEndPosition
+          sequence
         }
       }
     }

--- a/build/openServices/common/resolverOpenTools.js
+++ b/build/openServices/common/resolverOpenTools.js
@@ -23,8 +23,10 @@ var _sigmulon_resolver = require('../sigmulonService/sigmulon_resolver');
 
 var _ht_search_resolver = require('../htService/ht_search_resolver');
 
+var _srna_resolver = require('../srnaService/srna_resolver');
+
 /** merges all resolver file and exports them to index */
 
-/** import each Resolver file */
-const resolvers = exports.resolvers = (0, _mergeGraphqlSchemas.mergeResolvers)([_gene_resolver.geneResolvers, _phrasesResolvers.phrasesResolvers, _operon_resolver.operonResolvers, _coexpressionResolver.coexpressionResolver, _overviews_resolver.overviewsResolver, _regulon_resolver.regulonResolvers, _sigmulon_resolver.sigmulonResolvers]);
 //import { regulonResolvers } from '../regulonService/regulon_resolver';
+const resolvers = exports.resolvers = (0, _mergeGraphqlSchemas.mergeResolvers)([_gene_resolver.geneResolvers, _phrasesResolvers.phrasesResolvers, _operon_resolver.operonResolvers, _coexpressionResolver.coexpressionResolver, _overviews_resolver.overviewsResolver, _regulon_resolver.regulonResolvers, _sigmulon_resolver.sigmulonResolvers, _srna_resolver.srnaResolvers]);
+/** import each Resolver file */

--- a/build/openServices/common/schemaOpenTools.js
+++ b/build/openServices/common/schemaOpenTools.js
@@ -52,5 +52,9 @@ const HT = _apolloServerExpress.gql`
 ${_fs2.default.readFileSync('./src/openServices/htService/ht_search_schema.graphql').toString()}
 `;
 
+const SRNA = _apolloServerExpress.gql`
+${_fs2.default.readFileSync('./src/openServices/srnaService/srna_schema.graphql').toString()}
+`;
+
 /** Exports the merged Schema to the index to construct the GQL Server */
-const types = exports.types = (0, _mergeGraphqlSchemas.mergeTypes)([Gene, commonProperties, phrases, Operon, Regulon, Sigmulon, Coexpression, Overviews], { all: true });
+const types = exports.types = (0, _mergeGraphqlSchemas.mergeTypes)([Gene, commonProperties, phrases, Operon, Regulon, Sigmulon, Coexpression, Overviews, SRNA], { all: true });

--- a/build/openServices/operonService/operon_controller.js
+++ b/build/openServices/operonService/operon_controller.js
@@ -125,5 +125,5 @@ class operonController {
   }
 }
 
-/** the geneController is referenced by the resolver of the Gene web service */
+/** the operonController is referenced by the resolver of the Operon web service */
 exports.operonController = operonController;

--- a/build/openServices/operonService/operon_model.js
+++ b/build/openServices/operonService/operon_model.js
@@ -64,6 +64,20 @@ const operonSchema = new _mongoose2.default.Schema({
     statistics: operonStatisticsSchema
 });
 
+const boxesSchema = new _mongoose2.default.Schema({
+    leftEndPosition: String,
+    rightEndPosition: String,
+    sequence: String,
+    type: String
+});
+
+const tssSchema = new _mongoose2.default.Schema({
+    leftEndPosition: String,
+    rightEndPosition: String,
+    range: Number,
+    type: String
+});
+
 const promotersSchema = new _mongoose2.default.Schema({
     _id: String,
     bindsSigmaFactor: {
@@ -74,21 +88,11 @@ const promotersSchema = new _mongoose2.default.Schema({
     citations: [_general_model.citationsSchema],
     name: String,
     note: String,
-    boxes: [{
-        leftEndPosition: String,
-        rightEndPosition: String,
-        sequence: String,
-        type: String
-    }],
+    boxes: [boxesSchema],
     sequence: String,
     synonyms: [String],
     regulatorBindingSites: [RegulatorBindingSitesSchema],
-    transcriptionStartSite: {
-        leftEndPosition: String,
-        rightEndPosition: String,
-        range: Number,
-        type: String
-    }
+    transcriptionStartSite: tssSchema
 });
 
 const transcriptionTerminationSiteSchema = new _mongoose2.default.Schema({

--- a/build/openServices/regulonService/regulon_controller.js
+++ b/build/openServices/regulonService/regulon_controller.js
@@ -124,5 +124,5 @@ class regulonController {
   }
 }
 
-/** the geneController is referenced by the resolver of the Gene web service */
+/** the regulonController is referenced by the resolver of the Regulon web service */
 exports.regulonController = regulonController;

--- a/build/openServices/regulonService/regulon_model.js
+++ b/build/openServices/regulonService/regulon_model.js
@@ -169,7 +169,9 @@ const summarySchema = new _mongoose2.default.Schema({
   transcriptionFactors: summaryValuesSchema,
   transcriptionUnits: summaryValuesSchema,
   operons: summaryValuesSchema,
-  sigmaFactors: summaryValuesSchema
+  sigmaFactors: summaryValuesSchema,
+  regulatoryInteractions: summaryValuesSchema,
+  bindingSites: summaryValuesSchema
 });
 
 const regulonSchema = new _mongoose2.default.Schema({

--- a/build/openServices/sigmulonService/sigmulon_model.js
+++ b/build/openServices/sigmulonService/sigmulon_model.js
@@ -64,7 +64,7 @@ const SigmulonSchema = new _mongoose2.default.Schema({
     sigmaFactor: sigmaFactorSchema,
     transcribedPromoters: [transcribedPromotersSchema],
     statistics: statisticsSchema,
-    citations: [_general_model.citationsSchema]
+    allCitations: [_general_model.citationsSchema]
 });
 
 const Sigmulon = _mongoose2.default.model('sigmulon_datamarts', SigmulonSchema, 'sigmulonDatamart');

--- a/build/openServices/srnaService/srna_controller.js
+++ b/build/openServices/srnaService/srna_controller.js
@@ -3,9 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.sigmulonController = undefined;
+exports.srnaController = undefined;
 
-var _sigmulon_model = require('./sigmulon_model');
+var _srna_model = require('./srna_model');
 
 var _controller_common_functions = require('../common/controller_common_functions');
 
@@ -15,16 +15,16 @@ var _graphql = require('graphql');
 
 /** Define a geneController. */
 /**
-# [Sigmulon Service Controller]
+# [SRNA Service Controller]
 	
 ## Description
 
-[Defines functions to resolve GraphQL queries of Sigmulon Service]
+[Defines functions to resolve GraphQL queries of SRNA Service]
 
 ## Usage 
 
 ```javascript
-import { sigmulonController } from './sigmulon_controller';
+import { srnaController } from './srna_controller';
 ```
 
 ## Arguments/Parameters
@@ -56,7 +56,7 @@ RegulonDB Team: Lopez Almazo Andres Gerardo
 	
 # Functions description
 
-## [getSigmulonBy]
+## [getSrnaBy]
 
 __Description:__ 
 
@@ -66,7 +66,7 @@ __Description:__
 __Usage:__
 
 ```javascript
-operonController.getSigmulonBy(args);
+operonController.getSrnaBy(args);
 ```
 
 __Input arguments/parameters:__ 
@@ -77,7 +77,7 @@ __[advancedSearch]:__ usable for specific query by a "value[field]" syntax
 __[limit]:__ defines the page results showed (10 by default)
 __[page]:__ select the current result page (0 by default)
 __[properties]:__ select the fields to be queried by "search" (by default
-    geneInfo[id, name, synonyms] and products[name])
+    ["_id", "product.name", "product.synonyms"])
 __[organismName]:__ usable for specific organismName queries
 __[fullMatchOnly]:__ define if "search" will be Case Sensitive and cannot be a substring
     (by default "false")
@@ -88,8 +88,8 @@ __Object:__ Sigmulon
 Returns an object containing a response that will be sent to GraphQL
 **/
 
-class sigmulonController {
-    static async getOperonBy(search, advancedSearch, limit = 10, page = 0, properties = ['sigmaFactor._id', 'sigmaFactor.name', 'sigmaFactor.synonyms', 'transcribedPromoters.name'], fullMatchOnly = false) {
+class srnaController {
+    static async getSrnaBy(search, advancedSearch, limit = 10, page = 0, properties = ["_id", "product.name", "product.synonyms"], fullMatchOnly = false) {
         const offset = page * limit;
         let filter;
         let hasMore = false;
@@ -100,8 +100,8 @@ class sigmulonController {
             filter = (0, _mongodbFilterObjectParser.textSearchFilter)(search, properties, fullMatchOnly);
         }
 
-        const Sigmulons = _sigmulon_model.Sigmulon.find(filter).sort({ 'sigmaFactor.name': 1 }).limit(limit).skip(offset);
-        const total = await _controller_common_functions.commonController.countDocumentsIn(_sigmulon_model.Sigmulon, filter);
+        const SRNAS = _srna_model.SRNA.find(filter).sort({ 'product.name': 1 }).limit(limit).skip(offset);
+        const total = await _controller_common_functions.commonController.countDocumentsIn(_srna_model.SRNA, filter);
         const lastPage = Math.floor(total / limit);
         if (limit * (page + 1) < total) hasMore = true;
         if (page > lastPage) {
@@ -111,7 +111,7 @@ class sigmulonController {
             throw err;
         } else {
             return {
-                data: Sigmulons,
+                data: SRNAS,
                 pagination: {
                     limit: limit,
                     currentPage: page,
@@ -125,5 +125,5 @@ class sigmulonController {
     }
 }
 
-/** the sigmulonController is referenced by the resolver of the Sigmulon web service */
-exports.sigmulonController = sigmulonController;
+/** the srnaController is referenced by the resolver of the SRNA web service */
+exports.srnaController = srnaController;

--- a/build/openServices/srnaService/srna_model.js
+++ b/build/openServices/srnaService/srna_model.js
@@ -1,0 +1,85 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.SRNA = undefined;
+
+var _mongoose = require('mongoose');
+
+var _mongoose2 = _interopRequireDefault(_mongoose);
+
+var _general_model = require('../common/general_model');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const geneSchema = new _mongoose2.default.Schema({
+    _id: String,
+    name: String,
+    genomePosition: String,
+    strand: String,
+    gcContent: Number
+});
+
+const productSchema = new _mongoose2.default.Schema({
+    name: String,
+    gene: geneSchema,
+    synonyms: [String],
+    sequence: String,
+    note: String,
+    citations: [_general_model.citationsSchema],
+    externalCrossReferences: [_general_model.externalCrossReferencesSchema]
+});
+
+const RegulatedEntitySchema = new _mongoose2.default.Schema({
+    _id: String,
+    name: String,
+    type: String
+});
+
+const regulatoryBindingSiteSchema = new _mongoose2.default.Schema({
+    absolutePosition: Number,
+    leftEndPosition: Number,
+    rightEndPosition: Number,
+    sequence: String,
+    function: String
+});
+
+const RegulatoryInteractionsSchema = new _mongoose2.default.Schema({
+    _id: String,
+    regulatedEntity: RegulatedEntitySchema,
+    mechanism: [String],
+    function: String,
+    distanceToGene: Number,
+    regulatoryBindingSites: regulatoryBindingSiteSchema,
+    citations: [_general_model.citationsSchema]
+});
+
+const summaryValuesSchema = new _mongoose2.default.Schema({
+    repressed: Number,
+    activated: Number,
+    dual: Number,
+    unknown: Number,
+    total: Number
+});
+
+const summarySchema = new _mongoose2.default.Schema({
+    genes: summaryValuesSchema,
+    transcriptionFactors: summaryValuesSchema,
+    transcriptionUnits: summaryValuesSchema,
+    sigmaFactors: summaryValuesSchema,
+    regulatoryInteractions: summaryValuesSchema,
+    bindingSites: summaryValuesSchema
+});
+
+const SrnaSchema = new _mongoose2.default.Schema({
+    _id: String,
+    product: productSchema,
+    regulatoryInteractions: [RegulatoryInteractionsSchema],
+    summary: summarySchema,
+    allCitations: [_general_model.citationsSchema]
+});
+
+const SRNA = _mongoose2.default.model('srna_datamarts', SrnaSchema, 'srnaDatamart');
+
+exports.SRNA = SRNA;

--- a/build/openServices/srnaService/srna_resolver.js
+++ b/build/openServices/srnaService/srna_resolver.js
@@ -1,0 +1,58 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.srnaResolvers = undefined;
+
+var _srna_model = require('./srna_model');
+
+var _srna_controller = require('./srna_controller');
+
+var _controller_common_functions = require('../common/controller_common_functions');
+
+const srnaResolvers = exports.srnaResolvers = {
+  Query: {
+    getAllSrnas: (root, { limit, page }) => _controller_common_functions.commonController.getAll(_srna_model.SRNA, limit, page, 'product.name'),
+    getSrnaBy: (root, { search, advancedSearch, limit, page, properties, organismName, fullMatchOnly }) => _srna_controller.srnaController.getSrnaBy(search, advancedSearch, limit, page, properties, organismName, fullMatchOnly)
+  }
+}; /**
+   # [SRNA Service Resolver]
+   	
+   ## Description
+   
+   [Resolves the GraphQL Query based on controller's response
+   for SRNA Service]
+   
+   ## Usage 
+   
+   ```javascript
+   import {srnaResolvers} from './srna_resolver'
+   ```
+   
+   ## Arguments/Parameters
+   
+   N/A
+   
+   ## Examples
+   
+   N/A
+   
+   ## Return 
+   
+   N/A
+   
+   ## Category
+   
+   RegulonDB datamart web service
+   
+   ## License
+   
+   MIT License
+   
+   ## Author 
+   
+   RegulonDB Team: Lopez Almazo Andres Gerardo
+   **/
+
+/** import the operonController that contains the resolver functions */

--- a/src/config/playground_Options.js
+++ b/src/config/playground_Options.js
@@ -3,8 +3,8 @@ export const playgroundTabs = {
     {
       endpoint: 'graphql',
       name: 'updates',
-      query: `# 10/05/2021
-# Added a first version of Sigmulon Service,
+      query: `# 11/06/2021
+# Added a first version of SRNA Service,
 # This version is for an upcoming release of RegulonDB GraphQL Web Services
 # In case of error or report a bug please contact us
 
@@ -13,22 +13,28 @@ export const playgroundTabs = {
 # Select query, see "docs" tab to get description about 
 # parameters and description
 
-  getSigmulonBy(search:"fliA or \\\"Sigma 70\\\""){
+  getSrnaBy(search:"dicF"){
     data{
       _id
-      sigmaFactor{
+      product{
         name
         gene{
-        	name
+          _id
+          name
+          strand
         }
-    	}
-      transcribedPromoters{s
-        operon_id
-        _id
-        name
-        boxes{
+      }
+      regulatoryInteractions{
+        mechanism
+        regulatedEntity{
+          name
+          type
+        }
+        distanceToGene
+        regulatoryBindingSites{
           leftEndPosition
           rightEndPosition
+          sequence
         }
       }
     }

--- a/src/openServices/common/resolverOpenTools.js
+++ b/src/openServices/common/resolverOpenTools.js
@@ -9,6 +9,7 @@ import { overviewsResolver } from '../overviewsService/overviews_resolver'
 import { regulonResolvers } from '../regulonService/regulon_resolver'
 import { sigmulonResolvers } from '../sigmulonService/sigmulon_resolver'
 import { htResolvers } from '../htService/ht_search_resolver'
+import { srnaResolvers } from '../srnaService/srna_resolver'
 
 /** merges all resolver file and exports them to index */
 export const resolvers = mergeResolvers([
@@ -18,5 +19,6 @@ export const resolvers = mergeResolvers([
     coexpressionResolver,
     overviewsResolver,
     regulonResolvers,
-    sigmulonResolvers
+    sigmulonResolvers,
+    srnaResolvers
 ]);

--- a/src/openServices/common/schemaOpenTools.js
+++ b/src/openServices/common/schemaOpenTools.js
@@ -39,5 +39,9 @@ const HT = gql `
 ${fs.readFileSync('./src/openServices/htService/ht_search_schema.graphql').toString()}
 `;
 
+const SRNA = gql `
+${fs.readFileSync('./src/openServices/srnaService/srna_schema.graphql').toString()}
+`;
+
 /** Exports the merged Schema to the index to construct the GQL Server */
-export const types = mergeTypes([Gene, commonProperties, phrases, Operon, Regulon, Sigmulon, Coexpression, Overviews], {all: true});
+export const types = mergeTypes([Gene, commonProperties, phrases, Operon, Regulon, Sigmulon, Coexpression, Overviews, SRNA], {all: true});

--- a/src/openServices/geneService/gene_schema.graphql
+++ b/src/openServices/geneService/gene_schema.graphql
@@ -304,7 +304,7 @@ type Regulation {
   """
   _
   """
-  operon: Operon
+  operon: regulationOperon
   """
   _
   """
@@ -318,7 +318,7 @@ type Regulation {
 """
 _
 """
-type Operon {
+type regulationOperon {
   """
   _
   """

--- a/src/openServices/operonService/operon_controller.js
+++ b/src/openServices/operonService/operon_controller.js
@@ -123,5 +123,5 @@ class operonController {
 }
 }
 
-/** the geneController is referenced by the resolver of the Gene web service */
+/** the operonController is referenced by the resolver of the Operon web service */
 export {operonController};

--- a/src/openServices/operonService/operon_model.js
+++ b/src/openServices/operonService/operon_model.js
@@ -54,6 +54,20 @@ const operonSchema = new mongoose.Schema({
     statistics: operonStatisticsSchema
 });
 
+const boxesSchema = new mongoose.Schema({
+    leftEndPosition: String,
+    rightEndPosition: String,
+    sequence: String,
+    type: String
+});
+
+const tssSchema = new mongoose.Schema({
+    leftEndPosition: String,
+    rightEndPosition: String,
+    range: Number,
+    type: String
+});
+
 const promotersSchema = new mongoose.Schema({
     _id: String,
     bindsSigmaFactor: {
@@ -64,23 +78,11 @@ const promotersSchema = new mongoose.Schema({
     citations: [citationsSchema],
     name: String,
     note: String,
-    boxes: [
-        {
-            leftEndPosition: String,
-            rightEndPosition: String,
-            sequence: String,
-            type: String
-        }
-    ],
+    boxes: [boxesSchema],
     sequence: String,
     synonyms: [String],
     regulatorBindingSites: [RegulatorBindingSitesSchema],
-    transcriptionStartSite: {
-        leftEndPosition: String,
-        rightEndPosition: String,
-        range: Number,
-        type: String
-    }
+    transcriptionStartSite: tssSchema
 });
 
 const transcriptionTerminationSiteSchema = new mongoose.Schema ({

--- a/src/openServices/regulonService/regulon_controller.js
+++ b/src/openServices/regulonService/regulon_controller.js
@@ -121,5 +121,5 @@ class regulonController {
     }
 }
 
-/** the geneController is referenced by the resolver of the Gene web service */
+/** the regulonController is referenced by the resolver of the Regulon web service */
 export {regulonController};

--- a/src/openServices/regulonService/regulon_model.js
+++ b/src/openServices/regulonService/regulon_model.js
@@ -168,6 +168,8 @@ const summarySchema = new mongoose.Schema({
   transcriptionUnits: summaryValuesSchema,
   operons: summaryValuesSchema,
   sigmaFactors: summaryValuesSchema,
+  regulatoryInteractions: summaryValuesSchema,
+  bindingSites: summaryValuesSchema
 });
 
 const regulonSchema = new mongoose.Schema({

--- a/src/openServices/sigmulonService/sigmulon_controller.js
+++ b/src/openServices/sigmulonService/sigmulon_controller.js
@@ -123,5 +123,5 @@ class sigmulonController {
     }
 }
 
-/** the geneController is referenced by the resolver of the Gene web service */
+/** the sigmulonController is referenced by the resolver of the Sigmulon web service */
 export {sigmulonController};

--- a/src/openServices/sigmulonService/sigmulon_model.js
+++ b/src/openServices/sigmulonService/sigmulon_model.js
@@ -52,7 +52,7 @@ const SigmulonSchema = new mongoose.Schema({
     sigmaFactor: sigmaFactorSchema,
     transcribedPromoters: [transcribedPromotersSchema],
     statistics: statisticsSchema,
-    citations: [citationsSchema]
+    allCitations: [citationsSchema]
 });
 
 const Sigmulon = mongoose.model('sigmulon_datamarts', SigmulonSchema, 'sigmulonDatamart');

--- a/src/openServices/sigmulonService/sigmulon_schema.graphql
+++ b/src/openServices/sigmulonService/sigmulon_schema.graphql
@@ -3,7 +3,7 @@ type SigmulonDatamart {
     sigmaFactor: SigmaFactor
     transcribedPromoters: [TranscribedPromoters]
     statistics: SigmulonStatistics
-    citations: [Citations]
+    allCitations: [Citations]
 }
 
 type SigmaFactor {

--- a/src/openServices/srnaService/srna_controller.js
+++ b/src/openServices/srnaService/srna_controller.js
@@ -1,0 +1,127 @@
+/**
+# [SRNA Service Controller]
+	
+## Description
+
+[Defines functions to resolve GraphQL queries of SRNA Service]
+
+## Usage 
+
+```javascript
+import { srnaController } from './srna_controller';
+```
+
+## Arguments/Parameters
+
+N/A
+
+## Examples
+
+N/A
+
+## Return 
+
+N/A
+
+## Category
+
+RegulonDB datamart web service
+
+## License
+
+MIT License
+
+## Author 
+
+RegulonDB Team: Lopez Almazo Andres Gerardo
+**/
+
+
+/**
+	
+# Functions description
+
+## [getSrnaBy]
+
+__Description:__ 
+
+[Retrieve all documents that match with a query]
+
+
+__Usage:__
+
+```javascript
+operonController.getSrnaBy(args);
+```
+
+__Input arguments/parameters:__ 
+
+__[search]:__ usable for text search on fields defined in "Properties" parameter. **e.g.**:
+    "arad AND arac OR \"biosynthesis of macromolecules\""
+__[advancedSearch]:__ usable for specific query by a "value[field]" syntax
+__[limit]:__ defines the page results showed (10 by default)
+__[page]:__ select the current result page (0 by default)
+__[properties]:__ select the fields to be queried by "search" (by default
+    ["_id", "product.name", "product.synonyms"])
+__[organismName]:__ usable for specific organismName queries
+__[fullMatchOnly]:__ define if "search" will be Case Sensitive and cannot be a substring
+    (by default "false")
+
+__Return:__ 
+
+__Object:__ Sigmulon
+Returns an object containing a response that will be sent to GraphQL
+**/
+
+import { SRNA } from './srna_model';
+import { commonController } from '../common/controller_common_functions';
+import { advancedSearchFilter, textSearchFilter } from 'mongodb-filter-object-parser';
+import { GraphQLError } from 'graphql';
+
+/** Define a geneController. */
+class srnaController {
+  static async getSrnaBy(
+    search,
+    advancedSearch,
+    limit = 10,
+    page = 0,
+    properties = ["_id", "product.name", "product.synonyms"],
+    fullMatchOnly = false
+)   {
+        const offset = page * limit;
+        let filter;
+        let hasMore = false;
+        if (advancedSearch !== undefined) {
+        filter = advancedSearchFilter(advancedSearch);
+        } else if (search !== undefined) {
+        // filter = searchFilter(search);
+        filter = textSearchFilter(search, properties, fullMatchOnly);
+        }
+        
+        const SRNAS = SRNA.find(filter).sort({'product.name': 1}).limit(limit).skip(offset);
+        const total = await commonController.countDocumentsIn(SRNA, filter);
+        const lastPage = Math.floor(total / limit);
+        if (limit * (page + 1) < total) hasMore = true;
+        if (page > lastPage) {
+            const err = new GraphQLError('You must select an available page number');
+            err.status = 'No Content';
+            err.statusCode = 204;
+            throw err;
+        } else {
+        return {
+            data: SRNAS,
+            pagination: {
+            limit: limit,
+            currentPage: page,
+            firstPage: 0,
+            lastPage: lastPage,
+            totalResults: total,
+            hasNextPage: hasMore,
+            },
+        };
+        }
+    }
+}
+
+/** the srnaController is referenced by the resolver of the SRNA web service */
+export {srnaController};

--- a/src/openServices/srnaService/srna_model.js
+++ b/src/openServices/srnaService/srna_model.js
@@ -1,0 +1,73 @@
+import mongoose from "mongoose";
+import { citationsSchema, externalCrossReferencesSchema } from '../common/general_model';
+
+const geneSchema = new mongoose.Schema({
+    _id: String,
+    name: String,
+    genomePosition: String,
+    strand: String,
+    gcContent: Number
+});
+
+const productSchema = new mongoose.Schema({
+    name: String,
+    gene: geneSchema,
+    synonyms: [String],
+    sequence: String,
+    note: String,
+    citations: [citationsSchema],
+    externalCrossReferences: [externalCrossReferencesSchema]
+});
+
+const RegulatedEntitySchema = new mongoose.Schema({
+    _id: String,
+    name: String,
+    type: String
+});
+
+const regulatoryBindingSiteSchema = new mongoose.Schema({
+    absolutePosition: Number,
+    leftEndPosition: Number,
+    rightEndPosition: Number,
+    sequence: String,
+    function: String
+});
+
+const RegulatoryInteractionsSchema = new mongoose.Schema({
+    _id: String,
+    regulatedEntity: RegulatedEntitySchema,
+    mechanism: [String],
+    function: String,
+    distanceToGene: Number,
+    regulatoryBindingSites: regulatoryBindingSiteSchema,
+    citations: [citationsSchema]
+});
+
+const summaryValuesSchema = new mongoose.Schema({
+    repressed: Number,
+    activated: Number,
+    dual: Number,
+    unknown: Number,
+    total: Number,
+});
+  
+const summarySchema = new mongoose.Schema({
+    genes: summaryValuesSchema,
+    transcriptionFactors: summaryValuesSchema,
+    transcriptionUnits: summaryValuesSchema,
+    sigmaFactors: summaryValuesSchema,
+    regulatoryInteractions: summaryValuesSchema,
+    bindingSites: summaryValuesSchema
+});
+
+const SrnaSchema = new mongoose.Schema({
+    _id: String,
+    product: productSchema,
+    regulatoryInteractions: [RegulatoryInteractionsSchema],
+    summary: summarySchema,
+    allCitations: [citationsSchema]
+})
+
+const SRNA = mongoose.model('srna_datamarts', SrnaSchema, 'srnaDatamart')
+
+export {SRNA};

--- a/src/openServices/srnaService/srna_resolver.js
+++ b/src/openServices/srnaService/srna_resolver.js
@@ -1,0 +1,51 @@
+/**
+# [SRNA Service Resolver]
+	
+## Description
+
+[Resolves the GraphQL Query based on controller's response
+for SRNA Service]
+
+## Usage 
+
+```javascript
+import {srnaResolvers} from './srna_resolver'
+```
+
+## Arguments/Parameters
+
+N/A
+
+## Examples
+
+N/A
+
+## Return 
+
+N/A
+
+## Category
+
+RegulonDB datamart web service
+
+## License
+
+MIT License
+
+## Author 
+
+RegulonDB Team: Lopez Almazo Andres Gerardo
+**/
+
+/** import the operonController that contains the resolver functions */
+import { SRNA } from './srna_model';
+import { srnaController } from './srna_controller';
+import { commonController } from '../common/controller_common_functions';
+
+export const srnaResolvers = {
+  Query: {
+    getAllSrnas: (root, {limit, page}) => commonController.getAll(SRNA, limit, page, 'product.name'),
+    getSrnaBy: (root, {search, advancedSearch, limit, page, properties, organismName, fullMatchOnly}) =>
+      srnaController.getSrnaBy(search, advancedSearch, limit, page, properties, organismName, fullMatchOnly),
+  },
+};

--- a/src/openServices/srnaService/srna_schema.graphql
+++ b/src/openServices/srnaService/srna_schema.graphql
@@ -1,0 +1,293 @@
+# This schema represent srnaDatamart, principal Type is SrnaDatamart.
+# Types that can exist in differents datamart cannot be found here, 
+# and exists in "Common_properties" Schema in "Common" Folder
+# About descriptions
+# 
+# Each Type and Properties must have their own description defined at the 
+# top of it by triple double quotes like """this is a description""" replacing
+# the underscore with the description text
+
+"""
+_
+"""
+type SRNA {
+	"""
+	_
+	"""
+    _id: String
+	"""
+	_
+	"""
+    product: srnaProduct
+	"""
+	_
+	"""
+    regulatoryInteractions: [srnaRegulatoryInteractions]
+	"""
+	_
+	"""
+    summary: SrnaSummary
+	"""
+	_
+	"""
+    allCitations: [Citations]
+}
+
+"""
+_
+"""
+type srnaProduct {
+	"""
+	_
+	"""
+    name: String
+	"""
+	_
+	"""
+    gene: srnaGene
+	"""
+	_
+	"""
+    synonyms: [String]
+	"""
+	_
+	"""
+    sequence: String
+	"""
+	_
+	"""
+    note: String
+	"""
+	_
+	"""
+    citations: [Citations]
+	"""
+	_
+	"""
+    externalCrossReferences: [ExternalCrossReferences]
+}
+
+"""
+_
+"""
+type srnaGene {
+	"""
+	_
+	"""
+    _id: String
+	"""
+	_
+	"""
+    name: String,
+	"""
+	_
+	"""
+    genomePosition: String
+	"""
+	_
+	"""
+    strand: String
+	"""
+	_
+	"""
+    gcContent: Float
+}
+
+"""
+_
+"""
+type srnaRegulatoryInteractions {
+	"""
+	_
+	"""
+    _id: String
+	"""
+	_
+	"""
+    regulatedEntity: RegulatedEntity
+	"""
+	_
+	"""
+    mechanism: [String]
+	"""
+	_
+	"""
+    function: String
+	"""
+	_
+	"""
+    distanceToGene: Int
+	"""
+	_
+	"""
+    regulatoryBindingSites: RegulatoryBindingSites
+	"""
+	_
+	"""
+    citations: [Citations]
+}
+
+"""
+_
+"""
+type SrnaSummary {
+	"""
+	_
+	"""
+	genes: SummaryObject
+	"""
+	_
+	"""
+	transcriptionFactors: SummaryObject
+	"""
+	_
+	"""
+	transcriptionUnits: SummaryObject
+	"""
+	_
+	"""
+	sigmaFactors: SummaryObject
+	"""
+	_
+	"""
+	bindingSites: SummaryObject
+	"""
+	_
+	"""
+	regulatoryInteractions: SummaryObject
+}
+
+"""
+_
+"""
+type srnaDatamart { 
+  """
+  contains server response
+  """
+  data: [SRNA]
+  """
+  contains pagination info
+  """
+  pagination: Pagination
+}
+
+type Query {
+    """
+    #### Type
+    Data
+    #### Service
+    SRNA
+    #### Name
+    getAllSrnas
+    #### Description
+    List all the SRNA objects contained in collection
+    #### Example
+    ```json
+    {
+        getAllSrnas(limit:5){
+            data{
+                product{
+                    name
+                    synonyms
+                    gene{
+                        _id
+                        name
+                    }
+                }
+            }
+        }
+    }
+    ```
+    """
+    getAllSrnas(
+    """
+    #### Description
+    defines the page results showed 
+    #### Required
+    Optional
+    """
+    limit: Int = 10, 
+    """
+    #### Description
+    select the current result page 
+    #### Required
+    Optional
+    """
+    page: Int = 0): srnaDatamart!
+
+
+    """
+    #### Type
+    Data
+    #### Service
+    SRNA
+    #### Name
+    getSrnaBy
+    #### Description
+    List the SRNA objects obtained by a search or advancedSearch String
+    #### Example
+    ```json
+    {
+        getSrnaBy(search:"dicF"){
+            data{
+                product{
+                    name
+                    synonyms
+                    gene{
+                        _id
+                        name
+                        gcContent
+                        genomePosition
+                    }
+                }
+            }
+        }
+    }
+    ```
+    """
+    getSrnaBy(
+    """
+    #### Description
+    usable for text search on fields defined in \"Properties\" parameter; syntax; 
+    supports logic operators (AND,OR,NOT). **eg**: \"arad AND arac OR \"biosynthesis of macromolecules\"\"
+    #### Required
+    You must use search or advancedSearch
+    """
+    search: String, 
+    """
+    #### Description
+    usable for queries that require advanced control, uses a \"value[field]\" syntax; 
+    supports logic operators (AND,OR,NOT). **eg**: \"(arac|arad[operon.name] AND arab[transcriptionUnit.name])\"
+    #### Required
+    You must use search or advancedSearch
+    """
+    advancedSearch: String, 
+    """
+    #### Description
+    defines the page results showed
+    #### Required
+    Optional
+    """
+    limit: Int = 10, 
+    """
+    #### Description
+    select the current result page
+    #### Required
+    Optional
+    """
+    page: Int = 0, 
+    """
+    #### Description
+    select the fields to be queried by \"search\"
+    #### Required
+    Optional
+    """
+    properties: [String] = ["_id", "product.name", "product.synonyms"],
+    """
+    #### Description
+    define if \"search\" will be Case Sensitive and cannot be a substring
+    #### Required
+    Optional
+    """
+    fullMatchOnly: Boolean = false): srnaDatamart!
+}

--- a/test/openServicesTests/sigmulonService.test.js
+++ b/test/openServicesTests/sigmulonService.test.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-describe('geneService', () => {
+describe('sigmulonService', () => {
   test('getAllSigmulon with limit 3', async () => {
     const response = await axios.post('http://localhost:4001/graphql', {
       query: `
@@ -58,7 +58,7 @@ describe('geneService', () => {
       });
   });
 
-  test('getGenesBy Advanced Search', async () => {
+  test('getSigmulonBy Advanced Search', async () => {
     const response = await axios.post('http://localhost:4001/graphql', {
       query: `
             query{

--- a/test/openServicesTests/srnaService.test.js
+++ b/test/openServicesTests/srnaService.test.js
@@ -1,0 +1,149 @@
+import axios from 'axios';
+
+describe('srnaService', () => {
+  test('getAllSrnas with limit 5', async () => {
+    const response = await axios.post('http://localhost:4001/graphql', {
+      query: `
+            query{
+                getAllSrnas(limit:5){
+                  data{
+                    _id
+                    product{
+                      name
+                      gene{
+                        _id
+                        name
+                        strand
+                        gcContent
+                        genomePosition
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+    });
+
+    const {data} = response;
+    expect(data).toMatchObject({
+        "data": {
+          "getAllSrnas": {
+            "data": [
+              {
+                "_id": "RDBECOLIPDC00016",
+                "product": {
+                  "name": "6S RNA",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02536",
+                    "name": "ssrS",
+                    "strand": "forward",
+                    "gcContent": 55.19125683060109,
+                    "genomePosition": "3055983 --> 3056165"
+                  }
+                }
+              },
+              {
+                "_id": "RDBECOLIPDC03413",
+                "product": {
+                  "name": "CP4-44 prophage; small RNA IsrC",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02900",
+                    "name": "isrC",
+                    "strand": "forward",
+                    "gcContent": 42.56410256410256,
+                    "genomePosition": "2071317 --> 2071511"
+                  }
+                }
+              },
+              {
+                "_id": "RDBECOLIPDC04151",
+                "product": {
+                  "name": "CP4-6 prophage; small RNA EyeA",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02706",
+                    "name": "eyeA",
+                    "strand": "forward",
+                    "gcContent": 56,
+                    "genomePosition": "272580 --> 272654"
+                  }
+                }
+              },
+              {
+                "_id": "RDBECOLIPDC00328",
+                "product": {
+                  "name": "Qin prophage; small regulatory RNA DicF",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02552",
+                    "name": "dicF",
+                    "strand": "forward",
+                    "gcContent": 54.716981132075475,
+                    "genomePosition": "1649382 --> 1649434"
+                  }
+                }
+              },
+              {
+                "_id": "RDBECOLIPDC04181",
+                "product": {
+                  "name": "RNase P catalytic RNA component",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02506",
+                    "name": "rnpB",
+                    "strand": "reverse",
+                    "gcContent": 61.80371352785146,
+                    "genomePosition": "3270216 --> 3270592"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      });
+  });
+
+  test('getSrnaBy Advanced Search', async () => {
+    const response = await axios.post('http://localhost:4001/graphql', {
+      query: `
+            query{
+                getSrnaBy(search:"dicF"){
+                  data{
+                    _id
+                    product{
+                      name
+                      gene{
+                        _id
+                        name
+                        strand
+                        gcContent
+                        genomePosition
+                      }
+                    }
+                  }
+                }
+            }
+            `,
+    });
+
+    const {data} = response;
+    expect(data).toMatchObject({
+        "data": {
+          "getSrnaBy": {
+            "data": [
+              {
+                "_id": "RDBECOLIPDC00328",
+                "product": {
+                  "name": "Qin prophage; small regulatory RNA DicF",
+                  "gene": {
+                    "_id": "RDBECOLIGNC02552",
+                    "name": "dicF",
+                    "strand": "forward",
+                    "gcContent": 54.716981132075475,
+                    "genomePosition": "1649382 --> 1649434"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      });
+  });
+});


### PR DESCRIPTION
### Added

- SRNA Service was added in its first version of datamart as a Data Open Service in RegulonDB GraphQL Web Services. 
  - Some of this missing fields was:
    - Sigmulon - allCitations
    - Regulon - statistics
    - Operon - transcriptionUnits.promoters.boxes 

### Fixed

- Some bugs related to Regulon and Sigmulon services that cause missing fields on response were solved.