### PR TITLE
A bug solved related to genetic elements with no positions

### DIFF
--- a/build/closedServices/dttService/dttController.js
+++ b/build/closedServices/dttService/dttController.js
@@ -74,57 +74,44 @@ class dttController {
                 // When strand is "forward" OR "reverse"
                 if (strand != 'both')
                     // Return the elements that are completely contained in the selected range
-                    return _dttModel.Data.find({ $and: [{ leftEndPosition: { $gte: leftEndPosition } }, { rightEndPosition: { $lte: rightEndPosition } }, { strand: strand }, { objectType: { $in: objectType } }] });
+                    return _dttModel.Data.find({ $and: [{ $or: [{ leftEndPosition: { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }] }, { $or: [{ rightEndPosition: { $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] }, { strand: strand }, { objectType: { $in: objectType } }] });
 
                     // When strand is "forward" AND "reverse"
                 else
                     // Return the elements that are completely contained en the selected range
-                    return _dttModel.Data.find({ $and: [{ leftEndPosition: { $gte: leftEndPosition } }, { rightEndPosition: { $lte: rightEndPosition } }, { strand: { $in: ["forward", "reverse"] } }, { objectType: { $in: objectType } }] });
+                    return _dttModel.Data.find({ $and: [{ $or: [{ leftEndPosition: { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }] }, { $or: [{ rightEndPosition: { $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] }, { strand: { $in: ["forward", "reverse"] } }, { objectType: { $in: objectType } }] });
             }
             //When covered is false means draw both cases, when elements are contained in the range and those that not.
             else {
                     //When strand is "forward" OR "reverse"
-                    if (strand != 'both')
-                        // Return all elements that are contained in the selected range.
-                        return _dttModel.Data.find({ $and: [{ $or: [{ $and: [{ leftEndPosition: { $gte: leftEndPosition } }, { rightEndPosition: { $lte: rightEndPosition } }] },
-                                // Return those elements start outside the selected range but finish inside the range.
-                                { $and: [{ leftEndPosition: { $lt: leftEndPosition } }, { rightEndPosition: { $gt: leftEndPosition, $lte: rightEndPosition } }] },
-                                // Return those elements start inside the selected range but finish outside the range.
-                                { $and: [{ leftEndPosition: { $gte: leftEndPosition, $lte: rightEndPosition } }, { rightEndPosition: { $gt: rightEndPosition } }] },
-                                // Return those elements that start and finish outside the range
-                                { $and: [{ leftEndPosition: { $lte: leftEndPosition } }, { rightEndPosition: { $gte: rightEndPosition } }] }] }, { strand: strand }, { objectType: { $in: objectType } }] }).exec().
-                        // This function add to the position of the element a character "+" wich means if the position is outside the range
-                        then(dtt_response => {
-                            let dtt_obj_extracted;
-                            for (let i = 0; i < dtt_response.length; i++) {
-                                dtt_obj_extracted = dtt_response[i].toJSON();
-                                if (dtt_obj_extracted.leftEndPosition < leftEndPosition) dtt_obj_extracted.leftEndPosition = "+" + dtt_obj_extracted.leftEndPosition;
-                                if (dtt_obj_extracted.rightEndPosition > rightEndPosition) dtt_obj_extracted.rightEndPosition += "+";
-                                dtt_response[i] = dtt_obj_extracted;
-                            }
-                            return dtt_response;
-                        });
-                        // When strand is "forward" AND "reverse"
-                    else
-                        // Return all elements that are contained in the selected range.
-                        return _dttModel.Data.find({ $and: [{ $or: [{ $and: [{ leftEndPosition: { $gte: leftEndPosition } }, { rightEndPosition: { $lte: rightEndPosition } }] },
-                                // Return those elements start outside the selected range but finish inside the range.
-                                { $and: [{ leftEndPosition: { $lt: leftEndPosition } }, { rightEndPosition: { $gt: leftEndPosition, $lte: rightEndPosition } }] },
-                                // Return those elements start inside the selected range but finish outside the range.
-                                { $and: [{ leftEndPosition: { $gte: leftEndPosition, $lte: rightEndPosition } }, { rightEndPosition: { $gt: rightEndPosition } }] },
-                                // Return those elements that start and finish outside the range
-                                { $and: [{ leftEndPosition: { $lte: leftEndPosition } }, { rightEndPosition: { $gte: rightEndPosition } }] }] }, { strand: { $in: ["forward", "reverse"] } }, { objectType: { $in: objectType } }] }).exec().
-                        // This function add to the position of the element a character "+" wich means if the position is outside the range
-                        then(dtt_response => {
-                            let dtt_obj_extracted;
-                            for (let i = 0; i < dtt_response.length; i++) {
-                                dtt_obj_extracted = dtt_response[i].toJSON();
-                                if (dtt_obj_extracted.leftEndPosition < leftEndPosition) dtt_obj_extracted.leftEndPosition = "+" + dtt_obj_extracted.leftEndPosition;
-                                if (dtt_obj_extracted.rightEndPosition > rightEndPosition) dtt_obj_extracted.rightEndPosition += "+";
-                                dtt_response[i] = dtt_obj_extracted;
-                            }
-                            return dtt_response;
-                        });
+                    if (strand == 'both') strand = ["forward", "reverse"];
+                    // Return all elements that are contained in the selected range.
+                    return _dttModel.Data.find({ $and: [{ $or: [{ $and: [{ leftEndPosition: { $gte: leftEndPosition } }, { rightEndPosition: { $lte: rightEndPosition } }] },
+                            // Return those elements start outside the selected range but finish inside the range.
+                            { $and: [{ leftEndPosition: { $lt: leftEndPosition } }, { rightEndPosition: { $gt: leftEndPosition, $lte: rightEndPosition } }] },
+                            // Return those elements start inside the selected range but finish outside the range.
+                            { $and: [{ leftEndPosition: { $gte: leftEndPosition, $lte: rightEndPosition } }, { rightEndPosition: { $gt: rightEndPosition } }] },
+                            // Return those elements that start and finish outside the range
+                            { $and: [{ leftEndPosition: { $lte: leftEndPosition } }, { rightEndPosition: { $gte: rightEndPosition } }] },
+                            // Test for object when positions aren't defined, search in relatedObjects..
+                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] },
+                            // Return those elements start outside the selected range but finish inside the range.
+                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $lt: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gt: leftEndPosition, $lte: rightEndPosition } }] },
+                            // Return those elements start inside the selected range but finish outside the range.
+                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition, $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gt: rightEndPosition } }] },
+                            // Return those elements that start and finish outside the range
+                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $lte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gte: rightEndPosition } }] }] }, { strand: strand }, { objectType: { $in: objectType } }] }).exec().
+                    // This function add to the position of the element a character "+" wich means if the position is outside the range
+                    then(dtt_response => {
+                        let dtt_obj_extracted;
+                        for (let i = 0; i < dtt_response.length; i++) {
+                            dtt_obj_extracted = dtt_response[i].toJSON();
+                            if (dtt_obj_extracted.leftEndPosition != null && dtt_obj_extracted.leftEndPosition < leftEndPosition) dtt_obj_extracted.leftEndPosition = "+" + dtt_obj_extracted.leftEndPosition;
+                            if (dtt_obj_extracted.rightEndPosition != null && dtt_obj_extracted.rightEndPosition > rightEndPosition) dtt_obj_extracted.rightEndPosition += "+";
+                            dtt_response[i] = dtt_obj_extracted;
+                        }
+                        return dtt_response;
+                    });
                 }
         }
     }

--- a/build/closedServices/dttService/dttController.js
+++ b/build/closedServices/dttService/dttController.js
@@ -72,14 +72,9 @@ class dttController {
             // When covered is true means draw only the elements that are contained in the selected range
             if (covered) {
                 // When strand is "forward" OR "reverse"
-                if (strand != 'both')
-                    // Return the elements that are completely contained in the selected range
-                    return _dttModel.Data.find({ $and: [{ $or: [{ leftEndPosition: { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }] }, { $or: [{ rightEndPosition: { $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] }, { strand: strand }, { objectType: { $in: objectType } }] });
-
-                    // When strand is "forward" AND "reverse"
-                else
-                    // Return the elements that are completely contained en the selected range
-                    return _dttModel.Data.find({ $and: [{ $or: [{ leftEndPosition: { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }] }, { $or: [{ rightEndPosition: { $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] }, { strand: { $in: ["forward", "reverse"] } }, { objectType: { $in: objectType } }] });
+                if (strand == 'both') strand = ["forward", "reverse"];
+                // Return the elements that are completely contained in the selected range
+                return _dttModel.Data.find({ $and: [{ $or: [{ leftEndPosition: { $gte: leftEndPosition } }, { "linkedObjectWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }] }, { $or: [{ rightEndPosition: { $lte: rightEndPosition } }, { "linkedObjectWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] }, { $or: [{ strand: strand }, { strand: { $exists: false } }] }, { objectType: { $in: objectType } }] });
             }
             //When covered is false means draw both cases, when elements are contained in the range and those that not.
             else {
@@ -94,13 +89,13 @@ class dttController {
                             // Return those elements that start and finish outside the range
                             { $and: [{ leftEndPosition: { $lte: leftEndPosition } }, { rightEndPosition: { $gte: rightEndPosition } }] },
                             // Test for object when positions aren't defined, search in relatedObjects..
-                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] },
+                            { $and: [{ "linkedObjectWhenNoPositions.leftEndPosition": { $gte: leftEndPosition } }, { "linkedObjectWhenNoPositions.rightEndPosition": { $lte: rightEndPosition } }] },
                             // Return those elements start outside the selected range but finish inside the range.
-                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $lt: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gt: leftEndPosition, $lte: rightEndPosition } }] },
+                            { $and: [{ "linkedObjectWhenNoPositions.leftEndPosition": { $lt: leftEndPosition } }, { "linkedObjectWhenNoPositions.rightEndPosition": { $gt: leftEndPosition, $lte: rightEndPosition } }] },
                             // Return those elements start inside the selected range but finish outside the range.
-                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $gte: leftEndPosition, $lte: rightEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gt: rightEndPosition } }] },
+                            { $and: [{ "linkedObjectWhenNoPositions.leftEndPosition": { $gte: leftEndPosition, $lte: rightEndPosition } }, { "linkedObjectWhenNoPositions.rightEndPosition": { $gt: rightEndPosition } }] },
                             // Return those elements that start and finish outside the range
-                            { $and: [{ "linkedObjectsWhenNoPositions.leftEndPosition": { $lte: leftEndPosition } }, { "linkedObjectsWhenNoPositions.rightEndPosition": { $gte: rightEndPosition } }] }] }, { strand: strand }, { objectType: { $in: objectType } }] }).exec().
+                            { $and: [{ "linkedObjectWhenNoPositions.leftEndPosition": { $lte: leftEndPosition } }, { "linkedObjectWhenNoPositions.rightEndPosition": { $gte: rightEndPosition } }] }] }, { $or: [{ strand: strand }, { strand: { $exists: false } }] }, { objectType: { $in: objectType } }] }).exec().
                     // This function add to the position of the element a character "+" wich means if the position is outside the range
                     then(dtt_response => {
                         let dtt_obj_extracted;

--- a/build/closedServices/dttService/dttModel.js
+++ b/build/closedServices/dttService/dttModel.js
@@ -11,40 +11,13 @@ var _mongoose2 = _interopRequireDefault(_mongoose);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const dttDataObject = new _mongoose2.default.Schema({
+const linkedObjectsWhenNoPositionsSchema = new _mongoose2.default.Schema({
     _id: String,
-    objectType: String,
     leftEndPosition: Number,
+    name: String,
     rightEndPosition: Number,
     strand: String,
-    objectRGBColor: String,
-    lineWidth: Number,
-    lineType: Number,
-    labelName: String,
-    labelFont: String,
-    labelRGBColor: String,
-    labelSize: Number,
-    tooltip: String,
-    lineRGBColor: String,
-    organism: {
-        organism_id: String,
-        organism_name: String
-    },
-    relatedGenes: [{
-        gene_id: String,
-        effect: String,
-        objectRGBColor: String,
-        strand: String,
-        tooltip: String
-    }],
-    linkedObjectsWhenNoPositions: [{
-        _id: String,
-        leftEndPosition: Number,
-        name: String,
-        rightEndPosition: Number,
-        strand: String,
-        type: String
-    }]
+    type: String
 }); /**
      # Drawing Traces Tool service model
     
@@ -73,6 +46,35 @@ const dttDataObject = new _mongoose2.default.Schema({
     ## Author 
     
      **/
+
+const dttDataObject = new _mongoose2.default.Schema({
+    _id: String,
+    objectType: String,
+    leftEndPosition: Number,
+    rightEndPosition: Number,
+    strand: String,
+    objectRGBColor: String,
+    lineWidth: Number,
+    lineType: Number,
+    labelName: String,
+    labelFont: String,
+    labelRGBColor: String,
+    labelSize: Number,
+    tooltip: String,
+    lineRGBColor: String,
+    organism: {
+        organism_id: String,
+        organism_name: String
+    },
+    relatedGenes: [{
+        gene_id: String,
+        effect: String,
+        objectRGBColor: String,
+        strand: String,
+        tooltip: String
+    }],
+    linkedObjectsWhenNoPositions: [linkedObjectsWhenNoPositionsSchema]
+});
 
 const Data = _mongoose2.default.model('dnafeatures', dttDataObject, 'dnaFeatures');
 

--- a/build/closedServices/dttService/dttModel.js
+++ b/build/closedServices/dttService/dttModel.js
@@ -11,7 +11,7 @@ var _mongoose2 = _interopRequireDefault(_mongoose);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const linkedObjectsWhenNoPositionsSchema = new _mongoose2.default.Schema({
+const linkedObjectWhenNoPositionsSchema = new _mongoose2.default.Schema({
     _id: String,
     leftEndPosition: Number,
     name: String,
@@ -73,7 +73,7 @@ const dttDataObject = new _mongoose2.default.Schema({
         strand: String,
         tooltip: String
     }],
-    linkedObjectsWhenNoPositions: [linkedObjectsWhenNoPositionsSchema]
+    linkedObjectWhenNoPositions: linkedObjectWhenNoPositionsSchema
 });
 
 const Data = _mongoose2.default.model('dnafeatures', dttDataObject, 'dnaFeatures');

--- a/src/closedServices/dttService/dttController.js
+++ b/src/closedServices/dttService/dttController.js
@@ -73,37 +73,24 @@ class dttController {
             if (covered)
             {
                 // When strand is "forward" OR "reverse"
-                if(strand !='both')
+                if(strand == 'both')
+                    strand = ["forward","reverse"]
                 // Return the elements that are completely contained in the selected range
                     return Data.find({$and:[
                         {$or:[
                             {leftEndPosition: {$gte:leftEndPosition}}, 
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$gte:leftEndPosition}}
+                            {"linkedObjectWhenNoPositions.leftEndPosition":{$gte:leftEndPosition}}
                         ]}, 
                         {$or:[
                             {rightEndPosition: {$lte: rightEndPosition}}, 
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$lte:rightEndPosition}}
-                        ]}, 
-                        {strand: strand}, 
-                        {objectType: {$in: objectType}}
-                    ]});
-            
-                // When strand is "forward" AND "reverse"
-                else
-                // Return the elements that are completely contained en the selected range
-                    return Data.find({$and:[
-                        {$or:[
-                            {leftEndPosition: {$gte:leftEndPosition}}, 
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$gte:leftEndPosition}}
+                            {"linkedObjectWhenNoPositions.rightEndPosition":{$lte:rightEndPosition}}
                         ]}, 
                         {$or:[
-                            {rightEndPosition: {$lte: rightEndPosition}}, 
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$lte:rightEndPosition}}
-                        ]}, 
-                        {strand: {$in: ["forward","reverse"]}}, 
+                            {strand: strand},
+                            {strand: {$exists: false}}
+                        ]},
                         {objectType: {$in: objectType}}
                     ]});
-                
             }
             //When covered is false means draw both cases, when elements are contained in the range and those that not.
             else{
@@ -134,26 +121,29 @@ class dttController {
                         ]},
                         // Test for object when positions aren't defined, search in relatedObjects..
                         {$and:[
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$gte:leftEndPosition}},
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$lte:rightEndPosition}}
+                            {"linkedObjectWhenNoPositions.leftEndPosition":{$gte:leftEndPosition}},
+                            {"linkedObjectWhenNoPositions.rightEndPosition":{$lte:rightEndPosition}}
                         ]},
                         // Return those elements start outside the selected range but finish inside the range.
                         {$and:[
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$lt:leftEndPosition}},
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$gt:leftEndPosition,$lte:rightEndPosition}}
+                            {"linkedObjectWhenNoPositions.leftEndPosition":{$lt:leftEndPosition}},
+                            {"linkedObjectWhenNoPositions.rightEndPosition":{$gt:leftEndPosition,$lte:rightEndPosition}}
                         ]},
                         // Return those elements start inside the selected range but finish outside the range.
                         {$and:[
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$gte:leftEndPosition,$lte:rightEndPosition}},
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$gt:rightEndPosition}}
+                            {"linkedObjectWhenNoPositions.leftEndPosition":{$gte:leftEndPosition,$lte:rightEndPosition}},
+                            {"linkedObjectWhenNoPositions.rightEndPosition":{$gt:rightEndPosition}}
                         ]},
                         // Return those elements that start and finish outside the range
                         {$and:[
-                            {"linkedObjectsWhenNoPositions.leftEndPosition":{$lte:leftEndPosition}},
-                            {"linkedObjectsWhenNoPositions.rightEndPosition":{$gte:rightEndPosition}}
+                            {"linkedObjectWhenNoPositions.leftEndPosition":{$lte:leftEndPosition}},
+                            {"linkedObjectWhenNoPositions.rightEndPosition":{$gte:rightEndPosition}}
                         ]}
                     ]},
-                    {strand: strand},
+                    {$or:[
+                        {strand: strand},
+                        {strand: {$exists: false}}
+                    ]},
                     {objectType:{$in: objectType}}
                 ]}).exec().
                 // This function add to the position of the element a character "+" wich means if the position is outside the range

--- a/src/closedServices/dttService/dttModel.js
+++ b/src/closedServices/dttService/dttModel.js
@@ -29,6 +29,15 @@ RegulonDB drawing traces tool web service
 
 import mongoose from 'mongoose';
 
+const linkedObjectsWhenNoPositionsSchema = new mongoose.Schema({
+    _id: String,
+    leftEndPosition: Number,
+    name: String,
+    rightEndPosition: Number,
+    strand: String,
+    type: String
+})
+
 const dttDataObject = new mongoose.Schema({
     _id: String,
     objectType: String,
@@ -55,14 +64,7 @@ const dttDataObject = new mongoose.Schema({
         strand: String,
         tooltip: String
     }],
-    linkedObjectsWhenNoPositions: [{
-        _id: String,
-        leftEndPosition: Number,
-        name: String,
-        rightEndPosition: Number,
-        strand: String,
-        type: String
-    }]
+    linkedObjectsWhenNoPositions: [linkedObjectsWhenNoPositionsSchema]
 });
 
 const Data = mongoose.model('dnafeatures', dttDataObject, 'dnaFeatures');

--- a/src/closedServices/dttService/dttModel.js
+++ b/src/closedServices/dttService/dttModel.js
@@ -29,7 +29,7 @@ RegulonDB drawing traces tool web service
 
 import mongoose from 'mongoose';
 
-const linkedObjectsWhenNoPositionsSchema = new mongoose.Schema({
+const linkedObjectWhenNoPositionsSchema = new mongoose.Schema({
     _id: String,
     leftEndPosition: Number,
     name: String,
@@ -64,7 +64,7 @@ const dttDataObject = new mongoose.Schema({
         strand: String,
         tooltip: String
     }],
-    linkedObjectsWhenNoPositions: [linkedObjectsWhenNoPositionsSchema]
+    linkedObjectWhenNoPositions: linkedObjectWhenNoPositionsSchema
 });
 
 const Data = mongoose.model('dnafeatures', dttDataObject, 'dnaFeatures');

--- a/src/closedServices/dttService/dttSchema.graphql
+++ b/src/closedServices/dttService/dttSchema.graphql
@@ -82,7 +82,7 @@ type DTTData {
     """
     Objects that don´t have position
     """
-    linkedObjectsWhenNoPositions: [linkedObjectsWhenNoPositionsType]
+    linkedObjectWhenNoPositions: linkedObjectWhenNoPositionsType
 
     """
     Genes related to the elements
@@ -136,7 +136,7 @@ type relatedGenesType {
 """
 linkedObjectsWhenNoPositionsType contains information of those elements without position
 """
-type linkedObjectsWhenNoPositionsType {
+type linkedObjectWhenNoPositionsType {
     """
     id of the gene with no position
     """


### PR DESCRIPTION
In the first release of RegulonDB DTT Web Services, aren't included queries when a genetic elements doesn't have positions but it haves a linkedObject, with this new version, this elements now can be queried. Also the property linkedObjectsWhenNoPositions was updated to be a object and renamed to linkedObjectWhenNoPositions

Modified Files:
 - dttController - Adding support to query genetic elements with linked object
 - dttSchema - Updated property linkedObjectsWhenNoPositions and renamed
 - dttModel - Updated property linkedObjectsWhenNoPositions and renamed
 