### PR TITLE
Update: Added id property to transcriptionFactor object

### DIFF
--- a/build/openServices/regulonService/regulon_model.js
+++ b/build/openServices/regulonService/regulon_model.js
@@ -46,6 +46,7 @@ const ConformationsSchema = new _mongoose2.default.Schema({
 });
 
 const transcriptionFactorSchema = new _mongoose2.default.Schema({
+  _id: String,
   name: String,
   synonyms: [String],
   note: String,

--- a/src/openServices/regulonService/regulon_model.js
+++ b/src/openServices/regulonService/regulon_model.js
@@ -34,6 +34,7 @@ const ConformationsSchema = new mongoose.Schema({
 })
 
 const transcriptionFactorSchema = new mongoose.Schema({
+  _id: String,
   name: String,
   synonyms: [String],
   note: String,

--- a/src/openServices/regulonService/regulon_schema.graphql
+++ b/src/openServices/regulonService/regulon_schema.graphql
@@ -60,6 +60,10 @@ type TranscriptionFactor {
 	"""
 	_
 	"""
+	_id: String
+	"""
+	_
+	"""
 	name: String
 	"""
 	_


### PR DESCRIPTION
## Description
In the previous version was missing id property on model in transcriptionFactor property object due that this property was not included on MongoDB Collection, with this added in a recent versión of RegulonDBDatamarts, GraphQL API updates model and schema to include this property

### Files changed
 - openServices/regulonService/regulon_schema.graphql: Added _id property on type transcriptionFactor 
 - openServices/regulonService/regulon_schema.js: Added _id property on transcriptionFactor object model