### PR TITLE
chore: Updated mongodb-object-filter-parser library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -553,8 +553,7 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.20",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "resolved": "",
               "dev": true
             }
           }
@@ -2119,8 +2118,7 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.20",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "resolved": "",
               "dev": true
             }
           }
@@ -2323,8 +2321,7 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.20",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+              "resolved": "",
               "dev": true
             }
           }
@@ -5375,11 +5372,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-retry": {
       "version": "1.3.1",
@@ -12823,9 +12815,9 @@
       }
     },
     "mongodb-filter-object-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mongodb-filter-object-parser/-/mongodb-filter-object-parser-1.2.4.tgz",
-      "integrity": "sha512-v0WsXYLJkwCqxYKisItoZXhiQuDJo5hDWXhOQlWDGRH0tGr3oug/rZw90DeS12YKVKoPxVnTl6bk2cQ2J+peGw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/mongodb-filter-object-parser/-/mongodb-filter-object-parser-1.2.5.tgz",
+      "integrity": "sha512-Ele6yLRm/T9o5VRmXlQH063+JEGwNh6+aRW2xvb6p/RukHhxEZrG8hFw7oDpHA6Mv0bW9S4wxPIQ2+YoqmKQNQ=="
     },
     "mongoose": {
       "version": "5.11.15",
@@ -16649,12 +16641,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "graphql": "^15.5.0",
     "graphql-import": "^1.0.2",
     "merge-graphql-schemas": "^1.7.8",
-    "mongodb-filter-object-parser": "^1.2.4",
+    "mongodb-filter-object-parser": "^1.2.5",
     "mongoose": "^5.11.15"
   },
   "devDependencies": {


### PR DESCRIPTION
The library that converts advancedSearch string to mongodb search filters was updated due an bug that not accept underscores in fields