### PR TITLE
Fix: Solved a error related to type field of positions

### DIFF
--- a/src/openServices/regulonService/regulon_schema.graphql
+++ b/src/openServices/regulonService/regulon_schema.graphql
@@ -440,11 +440,11 @@ type RegulonRegulatoryInteractions {
 	"""
 	_
 	"""
-	distanceToFirstGene: Int
+	distanceToFirstGene: Float
 	"""
 	_
 	"""
-	distanceToPromoter: Int
+	distanceToPromoter: Float 
 	"""
 	_
 	"""
@@ -524,7 +524,7 @@ type RegulatoryBindingSites {
 	"""
 	_
 	"""
-	absolutePosition: Int
+	absolutePosition: Float
 	"""
 	_
 	"""


### PR DESCRIPTION
Fixed a error related to type field of positions on regulatoryInteractions and regulatoryBindingSites
files edited:
 src/openServices/regulonService/regulon_schema.graphql : updated type from Int to Float of the following fields
 - regulatoryInteractions -> distanceToPromoter, distanceToFirstGene
 - regulatoryBindingSites -> absolutePosition