### PR TITLE
Feat: added a first version regulatoryNetwork service

### DIFF
--- a/build/closedServices/common/closedToolsResolver.js
+++ b/build/closedServices/common/closedToolsResolver.js
@@ -9,6 +9,9 @@ var _mergeGraphqlSchemas = require('merge-graphql-schemas');
 
 var _dttResolver = require('../dttService/dttResolver');
 
+var _regulatoryNetworkResolver = require('../regulatoryNetworkService/regulatoryNetworkResolver');
+
 // merge all resolvers files and exports them to index
-const resolversClosed = exports.resolversClosed = (0, _mergeGraphqlSchemas.mergeResolvers)([_dttResolver.dttResolver]);
+
 // Import each resolver file
+const resolversClosed = exports.resolversClosed = (0, _mergeGraphqlSchemas.mergeResolvers)([_dttResolver.dttResolver, _regulatoryNetworkResolver.regulatoryNetworkResolver]);

--- a/build/closedServices/common/closedToolsSchema.js
+++ b/build/closedServices/common/closedToolsSchema.js
@@ -16,8 +16,12 @@ var _fs2 = _interopRequireDefault(_fs);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 //Read all graphql schemas
-const Dtt = _apolloServerExpress.gql`${_fs2.default.readFileSync('./src/closedServices/dttService/dttSchema.graphql').toString()}`;
+const Dtt = _apolloServerExpress.gql`${_fs2.default.readFileSync('./src/closedServices/dttService/dttSchema.graphql').toString()}`; // Import all libraries to used
+
+
+const RegNet = _apolloServerExpress.gql`${_fs2.default.readFileSync('./src/closedServices/regulatoryNetworkService/regulatoryNetworkSchema.graphql').toString()}`;
+
+const commonProperties = _apolloServerExpress.gql`${_fs2.default.readFileSync('./src/closedServices/common/common_properties.graphql').toString()}`;
 
 //exports the object that contains all merge schemas
-// Import all libraries to used
-const typeDefsClosed = exports.typeDefsClosed = (0, _mergeGraphqlSchemas.mergeTypes)([Dtt], { all: true });
+const typeDefsClosed = exports.typeDefsClosed = (0, _mergeGraphqlSchemas.mergeTypes)([Dtt, RegNet, commonProperties], { all: true });

--- a/build/closedServices/dttService/dttController.js
+++ b/build/closedServices/dttService/dttController.js
@@ -68,7 +68,14 @@ class dttController {
             throw err;
         } else {
             //When objectType is not defined by the user takes all values by default
-            if (objectType == 'all') objectType = ['gene', 'promoter', 'operon', 'tf_binding_site', 'translational_tf_binding_site', 'srna', 'riboswitch', 'terminator', 'translational_attenuator', 'transcriptional_attenuator', 'ppGpp'];
+            if (objectType == 'all') objectType = ['gene', //Ready
+            'promoter', //Ready
+            'operon', 'tf_binding_site', //Ready
+            'translational_tf_binding_site', //Ready
+            'srna', //Ready
+            'riboswitch', 'terminator', //Ready
+            'translational_attenuator', 'transcriptional_attenuator', 'ppGpp' //Ready
+            ];
             // When covered is true means draw only the elements that are contained in the selected range
             if (covered) {
                 // When strand is "forward" OR "reverse"

--- a/build/closedServices/regulatoryNetworkService/regulatoryNetworkController.js
+++ b/build/closedServices/regulatoryNetworkService/regulatoryNetworkController.js
@@ -1,1 +1,72 @@
-"use strict";
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.regulatoryNetworkController = undefined;
+
+var _regulatoryNetworkModel = require('./regulatoryNetworkModel');
+
+var _graphql = require('graphql');
+
+/**
+ # Regulatory Network service controller
+
+ ## Description
+ Here are defined all functions with all logic to connect and get data from db,
+ they return responses obtained to the resolvers
+
+## Usage
+```javascript
+import {regulatoryNetworkController} from './regulatoryNetworkController';
+```
+
+##Arguments/parameters
+N/A
+
+## Examples
+N/A
+
+## Return 
+N/A
+
+## Category
+RegulonDB regulatory network web service
+
+## License 
+ISC
+
+## Author
+Andres Gerardo Lopez Almazo
+
+ **/
+
+/**
+# Function description
+## getGeneticElementsFromInterval
+_Description:_
+This function return nodes defined by id or name with objects regulated by this node and object 
+that regulate this node
+_Usage:_
+```javascript
+regulatoryNetworkController.getNodesOf(object_id, object_name, networkType);
+```
+_Input parameters:_
+object_id: id of the element (gene or transcription factor)
+object_name: name of the element (gene or transcription factor)
+networkType: network type of the node (TF-TF, Gene-Gene, TF-Gene)
+_Return:_
+regulatoryNetworkController: [dttData]
+**/
+
+// import defined model of the collection to be used
+class regulatoryNetworkController {
+    static getNodesOf(object_id, object_name, networkType = ["TF-TF", "TF-Gene", "Gene-Gene"]) {
+        if (object_id != null) return _regulatoryNetworkModel.RegulatoryNetwork.find({
+            $and: [{ _id: object_id }, { networkType: networkType }]
+        });else return _regulatoryNetworkModel.RegulatoryNetwork.find({
+            $and: [{ name: object_name }, { networkType: networkType }]
+        });
+    }
+}
+exports.regulatoryNetworkController = regulatoryNetworkController;

--- a/build/closedServices/regulatoryNetworkService/regulatoryNetworkModel.js
+++ b/build/closedServices/regulatoryNetworkService/regulatoryNetworkModel.js
@@ -14,7 +14,7 @@ var _general_model = require('../../openServices/common/general_model');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const nodeSchema = new _mongoose2.default.Schema({
-    id: String,
+    _id: String,
     name: String,
     type: String,
     regulatoryEffect: String,

--- a/build/closedServices/regulatoryNetworkService/regulatoryNetworkResolver.js
+++ b/build/closedServices/regulatoryNetworkService/regulatoryNetworkResolver.js
@@ -1,1 +1,44 @@
-"use strict";
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.regulatoryNetworkResolver = undefined;
+
+var _regulatoryNetworkController = require('./regulatoryNetworkController');
+
+const regulatoryNetworkResolver = exports.regulatoryNetworkResolver = {
+  Query: {
+    getNodesOf: (root, { object_id, object_name, networkType }) => _regulatoryNetworkController.regulatoryNetworkController.getNodesOf(object_id, object_name, networkType)
+  }
+}; /**
+    # Regulatory Network service resolver
+   
+    ## Description
+    Here are contained all resolver to defined queries in the Graphql schema
+    it´s used for the server definition 
+   
+   ## Usage
+   ```javascript
+   import {regulatoryNetworkResolver} from './regulatoryNetworkResolver';
+   ```
+   
+   ##Arguments/parameters
+   N/A
+   
+   ## Examples
+   
+   ## Return 
+   N/A
+   
+   ## Category
+   RegulonDB regulatory network web service
+   
+   ## License 
+   ISC
+   
+   ## Author
+   Andres Gerardo Lopez Almazo 
+   
+    **/
+// import regulatoryNetworkControler to use functions defined in it

--- a/src/closedServices/common/closedToolsResolver.js
+++ b/src/closedServices/common/closedToolsResolver.js
@@ -1,6 +1,7 @@
 import {mergeResolvers} from 'merge-graphql-schemas';
 // Import each resolver file
 import {dttResolver} from '../dttService/dttResolver';
+import { regulatoryNetworkResolver } from '../regulatoryNetworkService/regulatoryNetworkResolver';
 
 // merge all resolvers files and exports them to index
-export const resolversClosed = mergeResolvers([dttResolver]);
+export const resolversClosed = mergeResolvers([dttResolver, regulatoryNetworkResolver]);

--- a/src/closedServices/common/closedToolsSchema.js
+++ b/src/closedServices/common/closedToolsSchema.js
@@ -6,5 +6,9 @@ import fs from 'fs';
 //Read all graphql schemas
 const Dtt = gql `${fs.readFileSync('./src/closedServices/dttService/dttSchema.graphql').toString()}`;
 
+const RegNet = gql `${fs.readFileSync('./src/closedServices/regulatoryNetworkService/regulatoryNetworkSchema.graphql').toString()}`;
+
+const commonProperties = gql`${fs.readFileSync('./src/closedServices/common/common_properties.graphql').toString()}`;
+
 //exports the object that contains all merge schemas
-export const typeDefsClosed = mergeTypes([Dtt],{all: true});
+export const typeDefsClosed = mergeTypes([Dtt, RegNet, commonProperties],{all: true});

--- a/src/closedServices/common/common_properties.graphql
+++ b/src/closedServices/common/common_properties.graphql
@@ -1,0 +1,98 @@
+# This schema contains types that exists in differents datamart
+#
+# About descriptions
+# Each Type and Properties must have their own description defined at the 
+# top of it by triple double quotes like """this is a description""" replacing
+# the underscore with the description text
+
+"""
+_
+"""
+type ExternalCrossReferences {
+	"""
+	_
+	"""
+	externalCrossReferenceId: String
+	"""
+	_
+	"""
+	externalCrossReferenceName: String
+	"""
+	_
+	"""
+	objectId: String
+	"""
+	_
+	"""
+	url: String
+}
+
+"""
+_
+"""
+type Citations {
+	"""
+	_
+	"""
+	evidence: Evidence
+	"""
+	_
+	"""
+	publication: Publication
+}
+
+"""
+_
+"""
+type Evidence {
+	"""
+	_
+	"""
+	id: String
+	"""
+	_
+	"""
+	name: String
+	"""
+	_
+	"""
+	code: String
+	"""
+	_
+	"""
+	type: String
+}
+
+"""
+_
+"""
+type Publication {
+	"""
+	_
+	"""
+	id: String
+	"""
+	_
+	"""
+	authors: [String]
+	"""
+	_
+	"""
+	pmid: String
+	"""
+	_
+	"""
+	citation: String
+	"""
+	_
+	"""
+	url: String
+	"""
+	_
+	"""
+	title: String
+	"""
+	_
+	"""
+	year: Int
+}

--- a/src/closedServices/dttService/dttController.js
+++ b/src/closedServices/dttService/dttController.js
@@ -69,17 +69,17 @@ class dttController {
             //When objectType is not defined by the user takes all values by default
             if(objectType == 'all')
                 objectType = [
-                    'gene',
-                    'promoter',
+                    'gene', //Ready
+                    'promoter', //Ready
                     'operon',
-                    'tf_binding_site',
-                    'translational_tf_binding_site',
-                    'srna',
+                    'tf_binding_site', //Ready
+                    'translational_tf_binding_site', //Ready
+                    'srna', //Ready
                     'riboswitch',
-                    'terminator',
+                    'terminator', //Ready
                     'translational_attenuator',
                     'transcriptional_attenuator',
-                    'ppGpp'
+                    'ppGpp' //Ready
                 ];
             // When covered is true means draw only the elements that are contained in the selected range
             if (covered)

--- a/src/closedServices/dttService/dttSchema.graphql
+++ b/src/closedServices/dttService/dttSchema.graphql
@@ -213,7 +213,8 @@ type Query {
         strand:String,
         """
         #### Description
-        Defines the elements to display 
+        Defines the elements to display from this list: gene, promoter, operon, tf_binding_site, translational_tf_binding_site,
+        srna, riboswitch, terminator, translational_attenuator, transcriptional_attenuator, ppGpp
         #### Required
         Optional
         """

--- a/src/closedServices/regulatoryNetworkService/regulatoryNetworkController.js
+++ b/src/closedServices/regulatoryNetworkService/regulatoryNetworkController.js
@@ -1,0 +1,78 @@
+/**
+ # Regulatory Network service controller
+
+ ## Description
+ Here are defined all functions with all logic to connect and get data from db,
+ they return responses obtained to the resolvers
+
+## Usage
+```javascript
+import {regulatoryNetworkController} from './regulatoryNetworkController';
+```
+
+##Arguments/parameters
+N/A
+
+## Examples
+N/A
+
+## Return 
+N/A
+
+## Category
+RegulonDB regulatory network web service
+
+## License 
+ISC
+
+## Author
+Andres Gerardo Lopez Almazo
+
+ **/
+ 
+ /**
+# Function description
+
+## getGeneticElementsFromInterval
+
+_Description:_
+This function return nodes defined by id or name with objects regulated by this node and object 
+that regulate this node
+
+_Usage:_
+```javascript
+regulatoryNetworkController.getNodesOf(object_id, object_name, networkType);
+```
+_Input parameters:_
+object_id: id of the element (gene or transcription factor)
+object_name: name of the element (gene or transcription factor)
+networkType: network type of the node (TF-TF, Gene-Gene, TF-Gene)
+
+_Return:_
+regulatoryNetworkController: [dttData]
+
+**/
+ 
+ // import defined model of the collection to be used
+ import {RegulatoryNetwork} from './regulatoryNetworkModel';
+ import { GraphQLError } from 'graphql';
+
+ class regulatoryNetworkController {
+     static getNodesOf(object_id, object_name, networkType = ["TF-TF", "TF-Gene", "Gene-Gene"]){
+         if(object_id != null)
+             return RegulatoryNetwork.find({
+                 $and:[
+                    {_id: object_id},
+                    {networkType: networkType}
+                ]
+            })
+         else
+            return RegulatoryNetwork.find({
+                $and:[
+                   {name: object_name},
+                   {networkType: networkType}
+               ]
+           })
+     }
+ }
+ export {regulatoryNetworkController}

--- a/src/closedServices/regulatoryNetworkService/regulatoryNetworkModel.js
+++ b/src/closedServices/regulatoryNetworkService/regulatoryNetworkModel.js
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 import { citationsSchema } from '../../openServices/common/general_model';
 
 const nodeSchema = new mongoose.Schema({
-    id: String,
+    _id: String,
     name: String,
     type: String,
     regulatoryEffect: String,

--- a/src/closedServices/regulatoryNetworkService/regulatoryNetworkResolver.js
+++ b/src/closedServices/regulatoryNetworkService/regulatoryNetworkResolver.js
@@ -1,0 +1,38 @@
+/**
+ # Regulatory Network service resolver
+
+ ## Description
+ Here are contained all resolver to defined queries in the Graphql schema
+ it´s used for the server definition 
+
+## Usage
+```javascript
+import {regulatoryNetworkResolver} from './regulatoryNetworkResolver';
+```
+
+##Arguments/parameters
+N/A
+
+## Examples
+
+## Return 
+N/A
+
+## Category
+RegulonDB regulatory network web service
+
+## License 
+ISC
+
+## Author
+Andres Gerardo Lopez Almazo 
+
+ **/
+// import regulatoryNetworkControler to use functions defined in it
+import {regulatoryNetworkController} from './regulatoryNetworkController';
+
+export const regulatoryNetworkResolver = {
+    Query: {
+        getNodesOf: (root, {object_id, object_name, networkType}) => regulatoryNetworkController.getNodesOf(object_id, object_name, networkType)
+    }
+}

--- a/src/closedServices/regulatoryNetworkService/regulatoryNetworkSchema.graphql
+++ b/src/closedServices/regulatoryNetworkService/regulatoryNetworkSchema.graphql
@@ -1,7 +1,7 @@
 """
 RegulatoryNetwork type is principal type on the service
 """
-type RegulatoryNetwork {
+type RegulatoryNetwork {
     """
     _
     """
@@ -35,7 +35,7 @@ type Node {
     """
     _
     """
-    id: String
+    _id: String
     """
     _
     """
@@ -67,7 +67,7 @@ type Query {
     #### Example
     ```json
     {
-        getNodesFrom(objects:["MicF"] levels: 1){
+        getNodesOf(objects:["MicF"] levels: 1){
             _id
             name
             networkType
@@ -79,19 +79,26 @@ type Query {
     }
     ```
     """
-    getNodesFrom(
+    getNodesOf(
         """
         #### Description
-        Specifies the objects to be query (regulator name or id)
+        Specifies the object id to be query
         #### Required
         Required
         """
-        object: String, 
+        object_id: [String], 
+        """
+        #### Description
+        Specifies the object name to be query
+        #### Required
+        Required
+        """
+        object_name: [String], 
         """
         #### Description
         defines the number of levels to be showed 
         #### Required
         Optional
         """
-        levels: Int = 0): [RegulatoryNetwork]
+        networkType: [String]): [RegulatoryNetwork]
 }


### PR DESCRIPTION
This version contains the first version of service for regulatoryNetwork Tool. This is contained in the following path:
- src/closedServices/regulatoryNetworkDatamart

Also this version updates getGeneticElementsFromInterval query of Drawing Traces Tool Services adding a better description for this query documentation