### PR TITLE
Solved mistmatching property names on definition

### DIFF
--- a/build/dataServices/common/general_model.js
+++ b/build/dataServices/common/general_model.js
@@ -12,7 +12,7 @@ var _mongoose2 = _interopRequireDefault(_mongoose);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const evidenceSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	code: String,
 	type: String,
@@ -22,7 +22,7 @@ const evidenceSchema = new _mongoose2.default.Schema({
 const citationsSchema = exports.citationsSchema = new _mongoose2.default.Schema({
 	evidence: evidenceSchema,
 	publication: {
-		id: String,
+		_id: String,
 		pmid: String,
 		citation: String,
 		url: String,
@@ -40,7 +40,7 @@ const externalCrossReferencesSchema = exports.externalCrossReferencesSchema = ne
 });
 
 const organismSchema = exports.organismSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	name: String
 });
 

--- a/build/dataServices/geneService/gene_controller.js
+++ b/build/dataServices/geneService/gene_controller.js
@@ -65,7 +65,7 @@ class geneController {
      *  @param {String} fullMatchOnly define if "search" will be Case Sensitive and cannot be a substring 
      *  (by default "false")
      */
-  static async getGenesBy(search, advancedSearch, limit = 10, page = 0, properties = ['gene.id', 'gene.name', 'gene.synonyms', 'gene.type', 'gene.bnumber', 'products.name'], organismName, fullMatchOnly = false) {
+  static async getGenesBy(search, advancedSearch, limit = 10, page = 0, properties = ['gene._id', 'gene.name', 'gene.synonyms', 'gene.type', 'gene.bnumber', 'products.name'], organismName, fullMatchOnly = false) {
     const offset = page * limit;
     let filter;
     let hasMore = false;

--- a/build/dataServices/geneService/gene_model.js
+++ b/build/dataServices/geneService/gene_model.js
@@ -15,14 +15,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 const geneOntologyTermsProperties = new _mongoose2.default.Schema({
 	citations: [_general_model.citationsSchema],
-	id: String,
+	_id: String,
 	name: String,
 	productsId: [String]
 });
 
 const geneSchema = new _mongoose2.default.Schema({
 	bnumber: String,
-	id: String,
+	_id: String,
 	name: String,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -34,12 +34,12 @@ const geneSchema = new _mongoose2.default.Schema({
 	type: String,
 	synonyms: [String],
 	multifunTerms: [{
-		id: String,
+		_id: String,
 		label: String,
 		name: String
 	}],
 	fragments: [{
-		id: String,
+		_id: String,
 		name: String,
 		leftEndPosition: Number,
 		rightEndPosition: Number,
@@ -51,7 +51,7 @@ const geneSchema = new _mongoose2.default.Schema({
 });
 
 const motifsSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	dataSource: String,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -63,8 +63,8 @@ const motifsSchema = new _mongoose2.default.Schema({
 });
 
 const productSchema = new _mongoose2.default.Schema({
-	id: String,
-	regulon_id: String,
+	_id: String,
+	regulonId: String,
 	name: String,
 	molecularWeight: Number,
 	isoelectricPoint: Number,
@@ -86,7 +86,7 @@ const productSchema = new _mongoose2.default.Schema({
 });
 
 const shineDalgarnoSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	distanceToGene: Number,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -95,7 +95,7 @@ const shineDalgarnoSchema = new _mongoose2.default.Schema({
 });
 
 const regulatorsSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	type: String,
 	function: String
@@ -103,16 +103,16 @@ const regulatorsSchema = new _mongoose2.default.Schema({
 
 const regulationSchema = new _mongoose2.default.Schema({
 	operon: {
-		id: String,
+		_id: String,
 		name: String,
 		arrangement: [{
 			regulators: [regulatorsSchema],
 			promoters: [{
-				id: String,
+				_id: String,
 				name: String
 			}],
 			transcriptionUnit: {
-				id: String,
+				_id: String,
 				name: String
 			}
 		}]
@@ -126,7 +126,7 @@ const regulationSchema = new _mongoose2.default.Schema({
 });
 
 const growthConditionsSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	controlCondition: String,
 	experimentalCondition: String,
 	effect: String,

--- a/build/dataServices/operonService/operon_controller.js
+++ b/build/dataServices/operonService/operon_controller.js
@@ -64,7 +64,7 @@ class operonController {
    *  @param {String} fullMatchOnly define if "search" will be Case Sensitive and cannot be a substring 
    *  (by default "false")
    */
-  static async getOperonBy(search, advancedSearch, limit = 10, page = 0, properties = ['operon.id', 'operon.name'], fullMatchOnly = false) {
+  static async getOperonBy(search, advancedSearch, limit = 10, page = 0, properties = ['operon._id', 'operon.name'], fullMatchOnly = false) {
     const offset = page * limit;
     let filter;
     let hasMore = false;

--- a/build/dataServices/operonService/operon_model.js
+++ b/build/dataServices/operonService/operon_model.js
@@ -53,7 +53,7 @@ const operonStatisticsSchema = new _mongoose2.default.Schema({
 });
 
 const operonSchema = new _mongoose2.default.Schema({
-    id: String,
+    _id: String,
     citations: [_general_model.citationsSchema],
     name: String,
     regulationPositions: {
@@ -81,9 +81,9 @@ const tssSchema = new _mongoose2.default.Schema({
 const promotersSchema = new _mongoose2.default.Schema({
     _id: String,
     bindsSigmaFactor: {
-        sigmaFactor_id: String,
+        _id: String,
         citations: [_general_model.citationsSchema],
-        sigmaFactor_name: String
+        name: String
     },
     citations: [_general_model.citationsSchema],
     name: String,
@@ -104,16 +104,16 @@ const transcriptionTerminationSiteSchema = new _mongoose2.default.Schema({
 });
 
 const transcriptionUnitsSchema = new _mongoose2.default.Schema({
-    id: String,
+    _id: String,
     name: String,
     citations: [_general_model.citationsSchema],
     firstGene: {
         distanceToPromoter: Number,
-        gene_id: String,
-        gene_name: String
+        _id: String,
+        name: String
     },
     genes: [{
-        id: String,
+        _id: String,
         name: String,
         regulatorBindingSites: [RegulatorBindingSitesSchema]
     }],
@@ -139,13 +139,9 @@ const operonServiceSchema = new _mongoose2.default.Schema({
     _id: String,
     operon: operonSchema,
     transcriptionUnits: [transcriptionUnitsSchema],
-    organism: {
-        id: String,
-        name: String
-    },
     allCitations: [_general_model.citationsSchema],
     schemaVersion: Number,
-    organism: [_general_model.organismSchema]
+    organism: _general_model.organismSchema
 });
 
 const Operon = _mongoose2.default.model('operon_datamarts', operonServiceSchema, 'operonDatamart');

--- a/build/dataServices/regulonService/regulon_model.js
+++ b/build/dataServices/regulonService/regulon_model.js
@@ -19,14 +19,14 @@ const tusEncodingRegulatorSchema = new _mongoose2.default.Schema({
 });
 
 const encodedFromGenes = new _mongoose2.default.Schema({
-  gene_id: String,
-  gene_name: String,
+  _id: String,
+  name: String,
   genomePosition: String,
   length: Number
 });
 
 const encodedFromOperons = new _mongoose2.default.Schema({
-  operon_id: String,
+  _id: String,
   name: String,
   tusEncodingRegulator: [tusEncodingRegulatorSchema]
 });
@@ -37,7 +37,7 @@ const encodedFromSchema = new _mongoose2.default.Schema({
 });
 
 const ConformationsSchema = new _mongoose2.default.Schema({
-  id: String,
+  _id: String,
   name: String,
   type: String,
   effectorInteractionType: String,
@@ -71,18 +71,18 @@ const transcriptionFactorSchema = new _mongoose2.default.Schema({
 });
 
 const GeneTermSchema = new _mongoose2.default.Schema({
-  gene_id: String,
-  gene_name: String
+  _id: String,
+  name: String
 });
 
 const geneOntologySchema = new _mongoose2.default.Schema({
-  term_id: String,
+  _id: String,
   name: String,
   genes: [GeneTermSchema]
 });
 
 const multifunSchema = new _mongoose2.default.Schema({
-  id: String,
+  _id: String,
   name: String,
   genes: [GeneTermSchema]
 });
@@ -99,12 +99,12 @@ const termsSchema = new _mongoose2.default.Schema({
 });
 
 const firstGeneSchema = new _mongoose2.default.Schema({
-  id: String,
+  _id: String,
   name: String
 });
 
 const regulatedGenesSchema = new _mongoose2.default.Schema({
-  id: String,
+  _id: String,
   name: String,
   function: String,
   terms: termsSchema
@@ -113,29 +113,29 @@ const regulatedGenesSchema = new _mongoose2.default.Schema({
 const regulatesSchema = new _mongoose2.default.Schema({
   genes: [regulatedGenesSchema],
   transcriptionFactors: [{
-    id: String,
+    _id: String,
     name: String,
     function: String,
     genes: [regulatedGenesSchema]
   }],
   transcriptionUnits: [{
-    id: String,
+    _id: String,
     name: String,
     function: String,
     firstGene: firstGeneSchema,
     promoter: {
-      id: String,
+      _id: String,
       name: String
     }
   }],
   operons: [{
-    id: String,
+    _id: String,
     name: String,
     function: String,
     firstGene: firstGeneSchema
   }],
   sigmaFactors: [{
-    id: String,
+    _id: String,
     name: String,
     function: String,
     gene: firstGeneSchema
@@ -143,7 +143,7 @@ const regulatesSchema = new _mongoose2.default.Schema({
 });
 
 const regulatoryBindingSitesSchema = {
-  id: String,
+  _id: String,
   function: String,
   absolutePosition: Number,
   leftEndPosition: Number,
@@ -173,7 +173,7 @@ const regulatoryInteractionsSchema = {
   distanceToFirstGene: Number,
   distanceToPromoter: Number,
   regulatedGenes: [{
-    id: String,
+    _id: String,
     name: String
   }],
   regulatoryBindingSites: regulatoryBindingSitesSchema,
@@ -224,7 +224,7 @@ const regulonSchema = new _mongoose2.default.Schema({
   summary: summarySchema,
   organismName: String,
   allCitations: [_general_model.citationsSchema],
-  organism: [_general_model.organismSchema]
+  organism: _general_model.organismSchema
 });
 
 const Regulon = _mongoose2.default.model('regulon_datamarts', regulonSchema, "regulonDatamart");

--- a/build/dataServices/sigmulonService/sigmulon_model.js
+++ b/build/dataServices/sigmulonService/sigmulon_model.js
@@ -44,7 +44,7 @@ const transcribedPromotersSchema = new _mongoose2.default.Schema({
     _id: String,
     name: String,
     transcribedGenes: [transcribedGenesSchema],
-    operon_id: String,
+    operonId: String,
     sequence: String,
     boxes: [boxesSchema],
     citations: [_general_model.citationsSchema]
@@ -65,7 +65,7 @@ const SigmulonSchema = new _mongoose2.default.Schema({
     transcribedPromoters: [transcribedPromotersSchema],
     statistics: statisticsSchema,
     allCitations: [_general_model.citationsSchema],
-    organism: [_general_model.organismSchema]
+    organism: _general_model.organismSchema
 });
 
 const Sigmulon = _mongoose2.default.model('sigmulon_datamarts', SigmulonSchema, 'sigmulonDatamart');

--- a/build/dataServices/srnaService/srna_model.js
+++ b/build/dataServices/srnaService/srna_model.js
@@ -22,6 +22,7 @@ const geneSchema = new _mongoose2.default.Schema({
 });
 
 const productSchema = new _mongoose2.default.Schema({
+    _id: String,
     name: String,
     gene: geneSchema,
     synonyms: [String],
@@ -78,7 +79,7 @@ const SrnaSchema = new _mongoose2.default.Schema({
     regulatoryInteractions: [RegulatoryInteractionsSchema],
     summary: summarySchema,
     allCitations: [_general_model.citationsSchema],
-    organism: [_general_model.organismSchema]
+    organism: _general_model.organismSchema
 });
 
 const SRNA = _mongoose2.default.model('srna_datamarts', SrnaSchema, 'srnaDatamart');

--- a/build/htServices/common/general_model.js
+++ b/build/htServices/common/general_model.js
@@ -12,7 +12,7 @@ var _mongoose2 = _interopRequireDefault(_mongoose);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const evidenceSchema = new _mongoose2.default.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	code: String,
 	type: String
@@ -21,7 +21,7 @@ const evidenceSchema = new _mongoose2.default.Schema({
 const citationsSchema = exports.citationsSchema = new _mongoose2.default.Schema({
 	evidence: evidenceSchema,
 	publication: {
-		id: String,
+		_id: String,
 		pmid: String,
 		citation: String,
 		url: String,

--- a/build/htServices/htDataset/ht_dataset_controller.js
+++ b/build/htServices/htDataset/ht_dataset_controller.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 exports.htDatasetController = undefined;
 
@@ -9,60 +9,69 @@ var _ht_dataset_model = require("./ht_dataset_model");
 
 var _mongodbFilterObjectParser = require("mongodb-filter-object-parser");
 
-/**
-# [Dataset Service Controller]
-	
-## Description
-
-[Defines functions to resolve GraphQL queries of HT Dataset Service]
-
-## Usage 
-
-```javascript
-import {htDatasetController} from './ht_dataset_controller.js';
-```
-
-## Arguments/Parameters
-
-N/A
-
-## Examples
-
-N/A
-
-## Return 
-
-N/A
-
-## Category
-
-RegulonDB HT Web Service
-
-## License
-
-MIT License
-
-## Author 
-
-RegulonDB Team: Lopez Almazo Andres Gerardo
-**/
-
 class htDatasetController {
-  /** Makes a advancedSearch Query in collection
-   *  @param {String} advSearch the string that need to be parsed to valid BSON format 
-   *  for MongoDB Query, must have a format like key[value]
-   */
-  static async getDatasetsFromSearch(advSearch) {
-    const filter = (0, _mongodbFilterObjectParser.advancedSearchFilter)(advSearch);
-    return await _ht_dataset_model.HTDataset.find(filter);
-  }
+    /** Makes a advancedSearch Query in collection
+     *  @param {String} advSearch the string that need to be parsed to valid BSON format 
+     *  for MongoDB Query, must have a format like key[value]
+     */
+    static async getDatasetsFromSearch(advSearch) {
+        const filter = (0, _mongodbFilterObjectParser.advancedSearchFilter)(advSearch);
+        return await _ht_dataset_model.HTDataset.find(filter);
+    }
 
-  /** Get a single document based on its unique ID
-   *  @param {String} datasetID the unique ID linked to a specific document to be queried
-   */
-  static async getDatasetByID(datasetID) {
-    return await _ht_dataset_model.HTDataset.findOne({ "_id": datasetID });
-  }
-}
+    /** Get a single document based on its unique ID
+     *  @param {String} datasetID the unique ID linked to a specific document to be queried
+     */
+    static async getDatasetByID(datasetID) {
+        return await _ht_dataset_model.HTDataset.findOne({ "_id": datasetID });
+    }
+
+    static async getDatasetsWithMetadata(datasetType) {
+        // TODO: Esto se debe hacer sobre el collectionName en lugar del datasetType, porque buscará el archivo metadata asociado al tipo de colección 
+        // requerido
+        const Datasets = await _ht_dataset_model.HTDataset.find({ "datasetType": datasetType });
+        const Metadata = await _ht_dataset_model.MetadataCollection.findOne({ "$and": [{ "datasetType": datasetType }, { "status": "latest" }] });
+        return {
+            datasets: Datasets,
+            metadata: Metadata
+        };
+    }
+} /**
+  # [Dataset Service Controller]
+  	
+  ## Description
+  
+  [Defines functions to resolve GraphQL queries of HT Dataset Service]
+  
+  ## Usage 
+  
+  ```javascript
+  import {htDatasetController} from './ht_dataset_controller.js';
+  ```
+  
+  ## Arguments/Parameters
+  
+  N/A
+  
+  ## Examples
+  
+  N/A
+  
+  ## Return 
+  
+  N/A
+  
+  ## Category
+  
+  RegulonDB HT Web Service
+  
+  ## License
+  
+  MIT License
+  
+  ## Author 
+  
+  RegulonDB Team: Lopez Almazo Andres Gerardo
+  **/
 
 exports.htDatasetController = htDatasetController;

--- a/build/htServices/htDataset/ht_dataset_model.js
+++ b/build/htServices/htDataset/ht_dataset_model.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.HTDataset = undefined;
+exports.MetadataCollection = exports.HTDataset = undefined;
 
 var _mongoose = require('mongoose');
 
@@ -137,6 +137,18 @@ const htDatasetSchema = new _mongoose2.default.Schema({
     externalReferences: [externalReferencesSchema]
 });
 
+const metadataSchema = new _mongoose2.default.Schema({
+    _id: String,
+    datasetType: String,
+    metadataContent: String,
+    status: String
+});
+
 const HTDataset = _mongoose2.default.model('ht_dataset_datamarts', htDatasetSchema, 'dataset');
 
 exports.HTDataset = HTDataset;
+
+
+const MetadataCollection = _mongoose2.default.model('dataset_metadata', metadataSchema, "metadata");
+
+exports.MetadataCollection = MetadataCollection;

--- a/build/htServices/htDataset/ht_dataset_resolver.js
+++ b/build/htServices/htDataset/ht_dataset_resolver.js
@@ -52,6 +52,7 @@ RegulonDB Team: Lopez Almazo Andres Gerardo
 const htDatasetResolvers = exports.htDatasetResolvers = {
   Query: {
     getDatasetsFromSearch: (root, { advancedSearch }) => _ht_dataset_controller.htDatasetController.getDatasetsFromSearch(advancedSearch),
-    getDatasetByID: (root, { datasetID }) => _ht_dataset_controller.htDatasetController.getDatasetByID(datasetID)
+    getDatasetByID: (root, { datasetID }) => _ht_dataset_controller.htDatasetController.getDatasetByID(datasetID),
+    getDatasetsWithMetadata: (root, { datasetType }) => _ht_dataset_controller.htDatasetController.getDatasetsWithMetadata(datasetType)
   }
 };

--- a/build/toolsServices/dttService/dttModel.js
+++ b/build/toolsServices/dttService/dttModel.js
@@ -47,6 +47,11 @@ const linkedObjectWhenNoPositionsSchema = new _mongoose2.default.Schema({
     
      **/
 
+const organismSchema = new _mongoose2.default.Schema({
+    _id: String,
+    name: String
+});
+
 const dttDataObject = new _mongoose2.default.Schema({
     _id: String,
     objectType: String,
@@ -62,12 +67,9 @@ const dttDataObject = new _mongoose2.default.Schema({
     labelSize: Number,
     tooltip: String,
     lineRGBColor: String,
-    organism: {
-        organism_id: String,
-        organism_name: String
-    },
+    organism: organismSchema,
     relatedGenes: [{
-        gene_id: String,
+        _id: String,
         effect: String,
         objectRGBColor: String,
         strand: String,

--- a/src/dataServices/common/common_properties.graphql
+++ b/src/dataServices/common/common_properties.graphql
@@ -48,7 +48,7 @@ type Evidence {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -74,7 +74,7 @@ type Publication {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -104,25 +104,11 @@ type Publication {
 """
 _
 """
-type Operon {
-	"""
-	_
-	"""
-	id: String
-	"""
-	_
-	"""
-	name: String
-}
-
-"""
-_
-"""
 type Multifun {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -130,7 +116,7 @@ type Multifun {
 	"""
 	_
 	"""
-	gene_ids: [String]
+	geneIds: [String]
 }
 
 """
@@ -162,7 +148,7 @@ type CellularComponent {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -184,7 +170,7 @@ type MolecularFunction {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -206,7 +192,7 @@ type BiologicalProcess {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -221,7 +207,7 @@ type simpleType {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -265,7 +251,7 @@ type Organism {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""

--- a/src/dataServices/common/general_model.js
+++ b/src/dataServices/common/general_model.js
@@ -1,7 +1,7 @@
 import mongoose, { mongo } from 'mongoose';
 
 const evidenceSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	code: String,
 	type: String,
@@ -11,7 +11,7 @@ const evidenceSchema = new mongoose.Schema({
 export const citationsSchema = new mongoose.Schema({
 	evidence: evidenceSchema,
 	publication: {
-		id: String,
+		_id: String,
 		pmid: String,
 		citation: String,
 		url: String,
@@ -29,7 +29,7 @@ export const externalCrossReferencesSchema = new mongoose.Schema({
 });
 
 export const organismSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	name: String
 });
 

--- a/src/dataServices/geneService/gene_controller.js
+++ b/src/dataServices/geneService/gene_controller.js
@@ -60,7 +60,7 @@ class geneController {
       advancedSearch,
       limit = 10,
       page = 0,
-      properties = ['gene.id', 'gene.name', 'gene.synonyms', 'gene.type', 'gene.bnumber', 'products.name'],
+      properties = ['gene._id', 'gene.name', 'gene.synonyms', 'gene.type', 'gene.bnumber', 'products.name'],
       organismName,
       fullMatchOnly = false
   ) {

--- a/src/dataServices/geneService/gene_model.js
+++ b/src/dataServices/geneService/gene_model.js
@@ -3,14 +3,14 @@ import { citationsSchema, externalCrossReferencesSchema, organismSchema } from '
 
 const geneOntologyTermsProperties = new mongoose.Schema({
 	citations: [ citationsSchema ],
-	id: String,
+	_id: String,
 	name: String,
 	productsId: [ String ]
 });
 
 const geneSchema = new mongoose.Schema({
 	bnumber: String,
-	id: String,
+	_id: String,
 	name: String,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -23,14 +23,14 @@ const geneSchema = new mongoose.Schema({
 	synonyms: [ String ],
 	multifunTerms: [
 		{
-			id: String,
+			_id: String,
 			label: String,
 			name: String
 		}
 	],
 	fragments:[
 		{
-			id: String,
+			_id: String,
 			name: String,
 			leftEndPosition: Number,
 			rightEndPosition: Number,
@@ -43,7 +43,7 @@ const geneSchema = new mongoose.Schema({
 });
 
 const motifsSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	dataSource: String,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -55,8 +55,8 @@ const motifsSchema = new mongoose.Schema({
 });
 
 const productSchema = new mongoose.Schema({
-	id: String,
-	regulon_id: String,
+	_id: String,
+	regulonId: String,
 	name: String,
 	molecularWeight: Number,
 	isoelectricPoint: Number,
@@ -78,7 +78,7 @@ const productSchema = new mongoose.Schema({
 });
 
 const shineDalgarnoSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	distanceToGene: Number,
 	leftEndPosition: Number,
 	rightEndPosition: Number,
@@ -87,7 +87,7 @@ const shineDalgarnoSchema = new mongoose.Schema({
 });
 
 const regulatorsSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	type: String,
 	function: String
@@ -95,19 +95,19 @@ const regulatorsSchema = new mongoose.Schema({
 
 const regulationSchema = new mongoose.Schema({
 	operon: {
-		id: String,
+		_id: String,
 		name: String,
 		arrangement: [
 			{
 				regulators: [ regulatorsSchema ],
 				promoters: [
 					{
-						id: String,
+						_id: String,
 						name: String
 					}
 				],
 				transcriptionUnit: {
-					id: String,
+					_id: String,
 					name: String
 				}
 			}
@@ -122,7 +122,7 @@ const regulationSchema = new mongoose.Schema({
 });
 
 const growthConditionsSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	controlCondition: String,
 	experimentalCondition: String,
 	effect: String,

--- a/src/dataServices/geneService/gene_schema.graphql
+++ b/src/dataServices/geneService/gene_schema.graphql
@@ -60,7 +60,7 @@ type Gene {
   """
   
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -126,7 +126,7 @@ type MultifunTerms {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -144,7 +144,7 @@ type Fragments {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -174,7 +174,7 @@ type Products {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -244,7 +244,7 @@ type Motifs {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -290,7 +290,7 @@ type ShineDalgarnos {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -334,7 +334,7 @@ type regulationOperon {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -370,7 +370,7 @@ type Regulators {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -410,7 +410,7 @@ type GrowthConditions {
   """
   _
   """
-  id: String
+  _id: String
   """
   _
   """
@@ -460,7 +460,7 @@ type Query {
     getAllGenes(limit:5){
       data{
         gene{
-          id
+          _id
           name
           leftEndPosition
           rightEndPosition
@@ -504,7 +504,7 @@ type Query {
       data{
         gene{
           name
-          id
+          _id
           strand
         }
         products{
@@ -553,7 +553,7 @@ type Query {
     #### Required
     Optional
     """
-    properties: [String] = ["gene.id", "gene.name", "gene.synonyms", "gene.type", "gene.bnumber", "products.name"], 
+    properties: [String] = ["gene._id", "gene.name", "gene.synonyms", "gene.type", "gene.bnumber", "products.name"], 
     """
     #### Description
     usable for specific organismName queries (not available right now)

--- a/src/dataServices/operonService/operon_controller.js
+++ b/src/dataServices/operonService/operon_controller.js
@@ -59,7 +59,7 @@ class operonController {
     advancedSearch,
     limit = 10,
     page = 0,
-    properties = ['operon.id', 'operon.name'],
+    properties = ['operon._id', 'operon.name'],
     fullMatchOnly = false
 ) {
   const offset = page * limit;

--- a/src/dataServices/operonService/operon_model.js
+++ b/src/dataServices/operonService/operon_model.js
@@ -43,7 +43,7 @@ const operonStatisticsSchema = new mongoose.Schema({
 })
 
 const operonSchema = new mongoose.Schema({
-    id: String,
+    _id: String,
     citations: [citationsSchema],
     name: String,
     regulationPositions: {
@@ -71,9 +71,9 @@ const tssSchema = new mongoose.Schema({
 const promotersSchema = new mongoose.Schema({
     _id: String,
     bindsSigmaFactor: {
-        sigmaFactor_id: String,
+        _id: String,
         citations: [citationsSchema],
-        sigmaFactor_name: String
+        name: String
     },
     citations: [citationsSchema],
     name: String,
@@ -94,17 +94,17 @@ const transcriptionTerminationSiteSchema = new mongoose.Schema ({
 });
 
 const transcriptionUnitsSchema = new mongoose.Schema({
-    id: String,
+    _id: String,
     name: String,
     citations: [citationsSchema],
     firstGene: {
         distanceToPromoter: Number,
-        gene_id: String,
-        gene_name: String
+        _id: String,
+        name: String
     },
     genes: [
         {
-            id: String,
+            _id: String,
             name: String,
             regulatorBindingSites: [RegulatorBindingSitesSchema]
         }
@@ -133,13 +133,9 @@ const operonServiceSchema = new mongoose.Schema({
     _id: String,
     operon: operonSchema,
     transcriptionUnits: [transcriptionUnitsSchema],
-    organism: {
-        id: String,
-        name: String
-    },
     allCitations: [citationsSchema],
     schemaVersion: Number,
-	organism: [ organismSchema ]
+	organism: organismSchema
 })
 
 const Operon = mongoose.model('operon_datamarts', operonServiceSchema, 'operonDatamart')

--- a/src/dataServices/operonService/operon_schema.graphql
+++ b/src/dataServices/operonService/operon_schema.graphql
@@ -44,7 +44,7 @@ type Operon {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -106,7 +106,7 @@ type TranscriptionUnits {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -176,11 +176,11 @@ type FirstGene {
 	"""
 	_
 	"""
-	gene_id: String
+	_id: String
 	"""
 	_
 	"""
-	gene_name: String
+	name: String
 }
 
 """
@@ -190,7 +190,7 @@ type Genes {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -208,7 +208,7 @@ type Promoter {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -267,7 +267,7 @@ type BindsSigmaFactor {
 	"""
 	_
 	"""
-	sigmaFactor_id: String
+	_id: String
 	"""
 	_
 	"""
@@ -275,7 +275,7 @@ type BindsSigmaFactor {
 	"""
 	_
 	"""
-	sigmaFactor_name: String
+	name: String
 }
 
 """
@@ -513,12 +513,12 @@ type Query {
     getAllOperon(limit:5){
       data{
         operon{
-          id
+          _id
           name
           strand
         }
         transcriptionUnits{
-          id
+          _id
           name
         }
       }
@@ -558,12 +558,12 @@ type Query {
     getOperonBy(search: "accD or accBC"){
       data{
         operon{
-          id
+          _id
           name
           strand
         }
         transcriptionUnits{
-          id
+          _id
           name
         }
       }
@@ -608,7 +608,7 @@ type Query {
     #### Required
     Optional
     """
-    properties: [String] = ["operon.id", "operon.name"],
+    properties: [String] = ["operon._id", "operon.name"],
     """
     #### Description
     define if \"search\" will be Case Sensitive and cannot be a substring

--- a/src/dataServices/regulonService/regulon_model.js
+++ b/src/dataServices/regulonService/regulon_model.js
@@ -7,14 +7,14 @@ const tusEncodingRegulatorSchema = new mongoose.Schema({
 });
 
 const encodedFromGenes = new mongoose.Schema({
-  gene_id: String,
-  gene_name: String,
+  _id: String,
+  name: String,
   genomePosition: String,
   length: Number
 })
 
 const encodedFromOperons = new mongoose.Schema({
-  operon_id: String,
+  _id: String,
   name: String,
   tusEncodingRegulator: [tusEncodingRegulatorSchema]
 })
@@ -25,7 +25,7 @@ const encodedFromSchema = new mongoose.Schema({
 });
 
 const ConformationsSchema = new mongoose.Schema({
-  id: String,
+  _id: String,
   name: String,
   type: String,
   effectorInteractionType: String,
@@ -59,18 +59,18 @@ const transcriptionFactorSchema = new mongoose.Schema({
 });
 
 const GeneTermSchema = new mongoose.Schema({
-  gene_id: String,
-  gene_name: String
+  _id: String,
+  name: String
 })
 
 const geneOntologySchema = new mongoose.Schema({
-  term_id: String,
+  _id: String,
   name: String,
   genes: [GeneTermSchema]
 });
 
 const multifunSchema = new mongoose.Schema({
-  id: String,
+  _id: String,
   name: String,
   genes: [GeneTermSchema]
 });
@@ -87,13 +87,13 @@ const termsSchema = new mongoose.Schema({
 });
 
 const firstGeneSchema = new mongoose.Schema({
-  id: String,
+  _id: String,
   name: String,
 });
 
 const regulatedGenesSchema = new mongoose.Schema(
   {
-    id: String,
+    _id: String,
     name: String,
     function: String,
     terms: termsSchema,
@@ -103,7 +103,7 @@ const regulatesSchema = new mongoose.Schema({
   genes: [regulatedGenesSchema],
   transcriptionFactors: [
     {
-      id: String,
+      _id: String,
       name: String,
       function: String,
       genes: [regulatedGenesSchema]
@@ -111,19 +111,19 @@ const regulatesSchema = new mongoose.Schema({
   ],
   transcriptionUnits: [
     {
-      id: String,
+      _id: String,
       name: String,
       function: String,
       firstGene: firstGeneSchema,
       promoter: {
-        id: String,
+        _id: String,
         name: String,
       }
     },
   ],
   operons: [
     {
-      id: String,
+      _id: String,
       name: String,
       function: String,
       firstGene: firstGeneSchema,
@@ -131,7 +131,7 @@ const regulatesSchema = new mongoose.Schema({
   ],
   sigmaFactors: [
     {
-      id: String,
+      _id: String,
       name: String,
       function: String,
       gene: firstGeneSchema,
@@ -140,7 +140,7 @@ const regulatesSchema = new mongoose.Schema({
 });
 
 const regulatoryBindingSitesSchema = ({
-  id: String,
+  _id: String,
   function: String,
   absolutePosition: Number, 
   leftEndPosition: Number,
@@ -170,7 +170,7 @@ const regulatoryInteractionsSchema = ({
   distanceToFirstGene: Number,
   distanceToPromoter: Number,
   regulatedGenes: [{
-    id: String,
+    _id: String,
     name: String
   }],
   regulatoryBindingSites: regulatoryBindingSitesSchema,
@@ -221,7 +221,7 @@ const regulonSchema = new mongoose.Schema({
   summary: summarySchema,
   organismName: String,
   allCitations: [citationsSchema],
-	organism: [ organismSchema ]
+	organism: organismSchema
 });
 
 const Regulon = mongoose.model('regulon_datamarts', regulonSchema, "regulonDatamart");

--- a/src/dataServices/regulonService/regulon_schema.graphql
+++ b/src/dataServices/regulonService/regulon_schema.graphql
@@ -42,7 +42,7 @@ type RegulonDatamart {
 	"""
 	_
 	"""
-	organism: String
+	organism: Organism
 	"""
 	_
 	"""
@@ -154,7 +154,7 @@ type Conformations {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -192,11 +192,11 @@ type EncodedGenes {
 	"""
 	_
 	"""
-	gene_id: String
+	_id: String
 	"""
 	_
 	"""
-	gene_name: String
+	name: String
 	"""
 	_
 	"""
@@ -214,7 +214,7 @@ type EncodedOperon {
 	"""
 	_
 	"""
-	operon_id: String
+	_id: String
 	"""
 	_
 	"""
@@ -278,7 +278,7 @@ type RegulonGeneOntologyItem {
 	"""
 	_
 	"""
-	term_id: String
+	_id: String
 	"""
 	_
 	"""
@@ -296,7 +296,7 @@ type RegulonMultifun {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -314,11 +314,11 @@ type GeneTermsObject {
 	"""
 	_
 	"""
-	gene_id: String
+	_id: String
 	"""
 	_
 	"""
-	gene_name: String
+	name: String
 }
 
 """
@@ -354,7 +354,7 @@ type RegulatedGenes {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -376,7 +376,7 @@ type RegulatedTranscriptionFactors {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -398,7 +398,7 @@ type RegulatedTranscriptionUnits {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -424,7 +424,7 @@ type RegulatedOperons {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -446,7 +446,7 @@ type RegulatedSigmaFactors {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -465,6 +465,10 @@ type RegulatedSigmaFactors {
 _
 """
 type RegulonRegulatoryInteractions {
+	"""
+	_
+	"""
+	_id: String
 	"""
 	_
 	"""
@@ -572,7 +576,7 @@ type RegulatoryBindingSites {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""

--- a/src/dataServices/sigmulonService/sigmulon_model.js
+++ b/src/dataServices/sigmulonService/sigmulon_model.js
@@ -32,7 +32,7 @@ const transcribedPromotersSchema = new mongoose.Schema({
     _id: String,
     name: String,
     transcribedGenes: [transcribedGenesSchema],
-    operon_id: String,
+    operonId: String,
     sequence: String,
     boxes: [boxesSchema],
     citations: [citationsSchema]
@@ -53,7 +53,7 @@ const SigmulonSchema = new mongoose.Schema({
     transcribedPromoters: [transcribedPromotersSchema],
     statistics: statisticsSchema,
     allCitations: [citationsSchema],
-	organism: [ organismSchema ]
+	organism: organismSchema
 });
 
 const Sigmulon = mongoose.model('sigmulon_datamarts', SigmulonSchema, 'sigmulonDatamart');

--- a/src/dataServices/sigmulonService/sigmulon_schema.graphql
+++ b/src/dataServices/sigmulonService/sigmulon_schema.graphql
@@ -91,7 +91,7 @@ type TranscribedPromoters {
 	"""
 	_
 	"""
-    operon_id: String
+    operonId: String
 	"""
 	_
 	"""

--- a/src/dataServices/srnaService/srna_model.js
+++ b/src/dataServices/srnaService/srna_model.js
@@ -10,6 +10,7 @@ const geneSchema = new mongoose.Schema({
 });
 
 const productSchema = new mongoose.Schema({
+    _id: String,
     name: String,
     gene: geneSchema,
     synonyms: [String],
@@ -66,7 +67,7 @@ const SrnaSchema = new mongoose.Schema({
     regulatoryInteractions: [RegulatoryInteractionsSchema],
     summary: summarySchema,
     allCitations: [citationsSchema],
-	organism: [ organismSchema ]
+	organism: organismSchema 
 })
 
 const SRNA = mongoose.model('srna_datamarts', SrnaSchema, 'srnaDatamart')

--- a/src/dataServices/srnaService/srna_schema.graphql
+++ b/src/dataServices/srnaService/srna_schema.graphql
@@ -44,6 +44,10 @@ type srnaProduct {
 	"""
 	_
 	"""
+    _id: String
+	"""
+	_
+	"""
     name: String
 	"""
 	_

--- a/src/htServices/common/common_properties.graphql
+++ b/src/htServices/common/common_properties.graphql
@@ -66,7 +66,7 @@ type Evidence {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -92,7 +92,7 @@ type Publication {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""

--- a/src/htServices/common/general_model.js
+++ b/src/htServices/common/general_model.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
 const evidenceSchema = new mongoose.Schema({
-	id: String,
+	_id: String,
 	name: String,
 	code: String,
 	type: String
@@ -10,7 +10,7 @@ const evidenceSchema = new mongoose.Schema({
 export const citationsSchema = new mongoose.Schema({
 	evidence: evidenceSchema,
 	publication: {
-		id: String,
+		_id: String,
 		pmid: String,
 		citation: String,
 		url: String,

--- a/src/htServices/htDataset/ht_dataset_controller.js
+++ b/src/htServices/htDataset/ht_dataset_controller.js
@@ -37,6 +37,7 @@ RegulonDB Team: Lopez Almazo Andres Gerardo
 **/
 
 import {HTDataset} from "./ht_dataset_model"
+import { MetadataCollection } from "./ht_dataset_model"
 import {advancedSearchFilter} from 'mongodb-filter-object-parser'
 
 class htDatasetController {
@@ -54,6 +55,17 @@ class htDatasetController {
      */
     static async getDatasetByID(datasetID) {
         return await HTDataset.findOne({"_id": datasetID})
+    }
+
+    static async getDatasetsWithMetadata(datasetType){
+        // TODO: Esto se debe hacer sobre el collectionName en lugar del datasetType, porque buscará el archivo metadata asociado al tipo de colección 
+        // requerido
+        const Datasets = await HTDataset.find({"datasetType":datasetType})
+        const Metadata = await MetadataCollection.findOne({"$and":[{"datasetType": datasetType}, {"status": "latest"}]})
+        return {
+            datasets: Datasets,
+            metadata: Metadata
+        };
     }
 }
 

--- a/src/htServices/htDataset/ht_dataset_model.js
+++ b/src/htServices/htDataset/ht_dataset_model.js
@@ -125,6 +125,17 @@ const htDatasetSchema = new mongoose.Schema({
     externalReferences: [externalReferencesSchema]
 });
 
+const metadataSchema = new mongoose.Schema({
+    _id: String,
+    datasetType: String,
+    metadataContent: String,
+    status: String
+})
+
 const HTDataset = mongoose.model('ht_dataset_datamarts', htDatasetSchema, 'dataset');
 
 export { HTDataset };
+
+const MetadataCollection = mongoose.model('dataset_metadata', metadataSchema, "metadata");
+
+export { MetadataCollection };

--- a/src/htServices/htDataset/ht_dataset_resolver.js
+++ b/src/htServices/htDataset/ht_dataset_resolver.js
@@ -44,7 +44,8 @@ import { commonController } from '../common/controller_common_functions';
 export const htDatasetResolvers = {
   Query: {
     getDatasetsFromSearch: (root, {advancedSearch}) => htDatasetController.getDatasetsFromSearch(advancedSearch),
-    getDatasetByID: (root, {datasetID}) => htDatasetController.getDatasetByID(datasetID)
+    getDatasetByID: (root, {datasetID}) => htDatasetController.getDatasetByID(datasetID),
+    getDatasetsWithMetadata: (root, {datasetType}) => htDatasetController.getDatasetsWithMetadata(datasetType)
   },
 };
  

--- a/src/htServices/htDataset/ht_dataset_schema.graphql
+++ b/src/htServices/htDataset/ht_dataset_schema.graphql
@@ -7,6 +7,42 @@
 # top of it by triple double quotes like """this is a description""" replacing
 # the underscore with the description text
 
+"""
+_
+"""
+type htDatasets {
+    """
+    _
+    """
+    datasets: [Dataset]
+    """
+    _
+    """
+    metadata: MetadataType
+}
+
+"""
+_
+"""
+type MetadataType {
+    """
+    _
+    """
+    _id: String
+    """
+    _
+    """
+    datasetType: String
+    """
+    _
+    """
+    metadataContent: String
+    """
+    _
+    """
+    status: String
+}
+
 """ 
 This is a Dataset type
 """
@@ -490,4 +526,41 @@ type Query {
     Required
     """
     advancedSearch: String): [Dataset]
+
+    """
+    #### Type
+    HT Data
+    #### Service
+    HT Dataset
+    #### Name
+    getDatasetsWithMetadata
+    #### Description
+    Gets a specific dataset document by an datasetID 
+    #### Example
+    ```json
+    {
+        getDatasetsWithMetadata
+        {
+            datasets{
+                _id
+                objectsTested {
+                    _id
+                    name
+                    note
+                }
+            }
+            metadata
+        }
+    }
+    ```
+    """
+    getDatasetsWithMetadata( 
+    """
+    #### Description
+    Indicates to query the datasetType to retrieve
+    #### Required
+    Required
+    """
+    datasetType: String
+    ): htDatasets
 }

--- a/src/toolsServices/common/common_properties.graphql
+++ b/src/toolsServices/common/common_properties.graphql
@@ -48,7 +48,7 @@ type Evidence {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""
@@ -74,7 +74,7 @@ type Publication {
 	"""
 	_
 	"""
-	id: String
+	_id: String
 	"""
 	_
 	"""

--- a/src/toolsServices/dttService/dttModel.js
+++ b/src/toolsServices/dttService/dttModel.js
@@ -36,7 +36,12 @@ const linkedObjectWhenNoPositionsSchema = new mongoose.Schema({
     rightEndPosition: Number,
     strand: String,
     type: String
-})
+});
+
+const organismSchema = new mongoose.Schema({
+	_id: String,
+	name: String
+});
 
 const dttDataObject = new mongoose.Schema({
     _id: String,
@@ -53,12 +58,9 @@ const dttDataObject = new mongoose.Schema({
     labelSize: Number,
     tooltip: String,
     lineRGBColor: String,
-    organism: {
-        organism_id: String,
-        organism_name: String
-    },
+    organism: organismSchema,
     relatedGenes: [{
-        gene_id: String,
+        _id: String,
         effect: String,
         objectRGBColor: String,
         strand: String,

--- a/src/toolsServices/dttService/dttSchema.graphql
+++ b/src/toolsServices/dttService/dttSchema.graphql
@@ -80,7 +80,7 @@ type DTTData {
     organism: organismType
 
     """
-    Objects that don´t have position
+    Objects that don't have position
     """
     linkedObjectWhenNoPositions: linkedObjectWhenNoPositionsType
 
@@ -97,12 +97,12 @@ type organismType {
     """
     id of the organism type
     """
-    organism_id: String
+    _id: String
 
     """
     Name of the organism type
     """
-    organism_name:String
+    name:String
 }
 
 """
@@ -112,7 +112,7 @@ type relatedGenesType {
     """
     id of the related gene
     """
-    gene_id: String
+    _id: String
     """
     efect of the gene
     """

--- a/test/htServicesTests/dataset.test.js
+++ b/test/htServicesTests/dataset.test.js
@@ -32,7 +32,7 @@ describe('dataset', () => {
               ]
             }
           ],
-          "referenceGenome": "NC_000913.3"
+          "referenceGenome": "E.coli.MG1655"
         }
       }
     });

--- a/test/openServicesTests/operonService.test.js
+++ b/test/openServicesTests/operonService.test.js
@@ -109,40 +109,31 @@ describe('operonService', () => {
     expect(data).toMatchObject({
         "data": {
           "getOperonBy": {
-            "data":  [
-              {
-                "operon": {
-                  "name": "accBC",
-                  "strand": "forward"
-                },
-                "transcriptionUnits": [
-                  {
-                    "name": "accBC"
-                  },
-                  {
-                    "name": "accBC"
-                  }
-                ]
+            "data":  [{
+              "operon": {
+                "name": "accBC",
+                "strand": "forward"
               },
-              {
-                "operon": {
-                  "name": "accBC",
-                  "strand": "forward"
+              "transcriptionUnits": [
+                {
+                  "name": "accBC"
                 },
-                "transcriptionUnits": []
+                {
+                  "name": "accBC"
+                }
+              ]
+            },
+            {
+              "operon": {
+                "name": "accD",
+                "strand": "reverse"
               },
-              {
-                "operon": {
-                  "name": "accD",
-                  "strand": "reverse"
-                },
-                "transcriptionUnits": [
-                  {
-                    "name": "accD"
-                  }
-                ]
-              }
-            ]
+              "transcriptionUnits": [
+                {
+                  "name": "accD"
+                }
+              ]
+            }]
           }
         }
       });

--- a/test/openServicesTests/regulonServices.test.js
+++ b/test/openServicesTests/regulonServices.test.js
@@ -11,7 +11,7 @@ describe('regulonService', () => {
                         name
                         encodedFrom{
                         genes{
-                            gene_name
+                            name
                         }
                         operon{
                             name
@@ -35,7 +35,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "accB"
+                          "name": "accB"
                         }
                       ],
                       "operon": [
@@ -52,7 +52,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "acrR"
+                          "name": "acrR"
                         }
                       ],
                       "operon": [
@@ -69,7 +69,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "ada"
+                          "name": "ada"
                         }
                       ],
                       "operon": [
@@ -86,7 +86,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "adiY"
+                          "name": "adiY"
                         }
                       ],
                       "operon": [
@@ -103,7 +103,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "agaR"
+                          "name": "agaR"
                         }
                       ],
                       "operon": [
@@ -130,7 +130,7 @@ describe('regulonService', () => {
                         name
                         encodedFrom{
                         genes{
-                            gene_name
+                            name
                         }
                         operon{
                             name
@@ -154,7 +154,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "agaR"
+                          "name": "agaR"
                         }
                       ],
                       "operon": [
@@ -171,7 +171,7 @@ describe('regulonService', () => {
                     "encodedFrom": {
                       "genes": [
                         {
-                          "gene_name": "araC"
+                          "name": "araC"
                         }
                       ],
                       "operon": [

--- a/test/openServicesTests/sigmulonService.test.js
+++ b/test/openServicesTests/sigmulonService.test.js
@@ -7,7 +7,6 @@ describe('sigmulonService', () => {
             query{
                 getAllSigmulon(limit:3){
                 data{
-                    _id
                     sigmaFactor{
                             name
                             gene{
@@ -24,35 +23,30 @@ describe('sigmulonService', () => {
     expect(data).toMatchObject({
         "data": {
           "getAllSigmulon": {
-            "data": [
-              {
-                "_id": "RDBECOLISFC00004",
-                "sigmaFactor": {
-                  "name": "RNA polymerase sigma E factor",
-                  "gene": {
-                    "name": "rpoE"
-                  }
-                }
-              },
-              {
-                "_id": "RDBECOLISFC00002",
-                "sigmaFactor": {
-                  "name": "RNA polymerase sigma factor FecI",
-                  "gene": {
-                    "name": "fecI"
-                  }
-                }
-              },
-              {
-                "_id": "RDBECOLISFC00001",
-                "sigmaFactor": {
-                  "name": "RNA polymerase, sigma 28 (sigma F) factor",
-                  "gene": {
-                    "name": "fliA"
-                  }
+            "data": [{
+              "sigmaFactor": {
+                "name": "RNA polymerase sigma factor FecI",
+                "gene": {
+                  "name": "fecI"
                 }
               }
-            ]
+            },
+            {
+              "sigmaFactor": {
+                "name": "RNA polymerase sigma factor FliA",
+                "gene": {
+                  "name": "fliA"
+                }
+              }
+            },
+            {
+              "sigmaFactor": {
+                "name": "RNA polymerase sigma factor RpoD",
+                "gene": {
+                  "name": "rpoD"
+                }
+              }
+            }]
           }
         }
       });
@@ -62,9 +56,8 @@ describe('sigmulonService', () => {
     const response = await axios.post('http://localhost:4001/graphql', {
       query: `
             query{
-                getSigmulonBy(search:"fliA or \\\"Sigma 70\\\""){
+                getSigmulonBy(advancedSearch:"FliA[sigmaFactor.name]"){
                 data{
-                    _id
                     sigmaFactor{
                             name
                             gene{
@@ -81,26 +74,14 @@ describe('sigmulonService', () => {
     expect(data).toMatchObject({
         "data": {
           "getSigmulonBy": {
-            "data": [
-              {
-                "_id": "RDBECOLISFC00001",
-                "sigmaFactor": {
-                  "name": "RNA polymerase, sigma 28 (sigma F) factor",
-                  "gene": {
-                    "name": "fliA"
-                  }
-                }
-              },
-              {
-                "_id": "RDBECOLISFC00003",
-                "sigmaFactor": {
-                  "name": "RNA polymerase, sigma 70 (sigma D) factor",
-                  "gene": {
-                    "name": "rpoD"
-                  }
+            "data": [{
+              "sigmaFactor": {
+                "name": "RNA polymerase sigma factor FliA",
+                "gene": {
+                  "name": "fliA"
                 }
               }
-            ]
+            }]
           }
         }
       });


### PR DESCRIPTION
## Resume
Some property names were mispelled when the services were defined, this is solved eliminating all propery names that contain snake_case syntax and corrected to be camelCase, also all fields named "id" were updated to be "_id". 

- The test case files were updated

## New

- Added a new previous level for HT Datasets services in order to retrieve its metadata.