### PR TITLE
Update: The models and schemas are up to date to structure

### DIFF
--- a/build/dataServices/operonService/operon_model.js
+++ b/build/dataServices/operonService/operon_model.js
@@ -21,13 +21,13 @@ const RegulatorBindingSitesSchema = new _mongoose2.default.Schema({
     },
     regulatoryInteractions: [{
         _id: String,
-        centerPosition: Number,
+        relativeCenterPosition: Number,
         citations: [_general_model.citationsSchema],
         function: String,
         note: String,
         regulatorySite: {
             _id: String,
-            absolutePosition: Number,
+            centerEndPosition: Number,
             citations: [_general_model.citationsSchema],
             leftEndPosition: Number,
             length: Number,
@@ -35,10 +35,11 @@ const RegulatorBindingSitesSchema = new _mongoose2.default.Schema({
             rightEndPosition: Number,
             sequence: String
         },
-        mechanism: String,
+        mechanism: [String],
         additiveEvidences: [_general_model.aditiveEvidencesSchema]
     }],
-    function: String
+    function: String,
+    mechanism: [String]
 });
 
 const transcriptionUnitStatisticsSchema = new _mongoose2.default.Schema({

--- a/build/dataServices/regulonService/regulon_model.js
+++ b/build/dataServices/regulonService/regulon_model.js
@@ -42,6 +42,11 @@ const ConformationsSchema = new _mongoose2.default.Schema({
   name: String,
   type: String,
   effectorInteractionType: String,
+  effector: {
+    _id: String,
+    name: String
+  },
+  note: String,
   citations: [_general_model.citationsSchema],
   functionalType: String,
   additiveEvidences: [_general_model.aditiveEvidencesSchema],

--- a/src/dataServices/operonService/operon_model.js
+++ b/src/dataServices/operonService/operon_model.js
@@ -10,13 +10,13 @@ const RegulatorBindingSitesSchema = new mongoose.Schema({
     regulatoryInteractions: [
         {
             _id: String,
-            centerPosition: Number,
+            relativeCenterPosition: Number,
             citations: [citationsSchema],
             function: String,
             note: String,
             regulatorySite: {
                 _id: String,
-                absolutePosition: Number,
+                centerEndPosition: Number,
                 citations: [citationsSchema],
                 leftEndPosition: Number,
                 length: Number,
@@ -24,11 +24,12 @@ const RegulatorBindingSitesSchema = new mongoose.Schema({
                 rightEndPosition: Number,
                 sequence: String
             },
-            mechanism: String,
+            mechanism: [String],
             additiveEvidences: [aditiveEvidencesSchema],
         }
     ],
-    function: String
+    function: String,
+    mechanism: [String]
 })
 
 const transcriptionUnitStatisticsSchema = new mongoose.Schema({

--- a/src/dataServices/operonService/operon_schema.graphql
+++ b/src/dataServices/operonService/operon_schema.graphql
@@ -316,6 +316,10 @@ type RegulatorBindingSites {
 	_
 	"""
 	function: String
+	"""
+	_
+	"""
+	mechanism: [String]
 }
 
 """
@@ -347,7 +351,7 @@ type RegulatoryInteractions {
 	"""
 	_
 	"""
-	centerPosition: Float
+	relativeCenterPosition: Float
 	"""
 	_
 	"""
@@ -367,7 +371,7 @@ type RegulatoryInteractions {
 	"""
 	_
 	"""
-	mechanism: String
+	mechanism: [String]
 	"""
 	_
 	"""
@@ -385,7 +389,7 @@ type RegulatorySite {
 	"""
 	_
 	"""
-	absolutePosition: Float
+	centerEndPosition: Float
 	"""
 	_
 	"""

--- a/src/dataServices/regulonService/regulon_model.js
+++ b/src/dataServices/regulonService/regulon_model.js
@@ -30,6 +30,11 @@ const ConformationsSchema = new mongoose.Schema({
   name: String,
   type: String,
   effectorInteractionType: String,
+  effector: {
+    _id: String,
+    name: String
+  },
+  note: String,
   citations: [citationsSchema],
   functionalType: String,
   additiveEvidences: [aditiveEvidencesSchema],

--- a/src/dataServices/regulonService/regulon_schema.graphql
+++ b/src/dataServices/regulonService/regulon_schema.graphql
@@ -174,6 +174,14 @@ type Conformations {
 	"""
 	_
 	"""
+	effector: simpleType
+	"""
+	_
+	"""
+	note: String
+	"""
+	_
+	"""
 	citations: [Citations]
 	"""
 	_


### PR DESCRIPTION
The following changes were applied:

## Update
- On Operon collection some fields names and types were changed: 
> - In all levels, regulatoryBindingSite.RegulatoryInteraction.centerPosition to
regulatoryBindingSite.RegulatoryInteraction.relativeCenterPosition
> - In all levels, regulatoryBindingSite.RegulatoryInteraction.regulatorySite.absoluteCenterPosition to
regulatoryBindingSite.RegulatoryInteraction.regulatorySite.centerEndPosition
> - In all levels, regulatoryBindingSites.mechanism is now a String Array

- On Regulon collection the notes of the regulator conformations when this is a transcription factor now includes their note and a effector object if the conformation is a complex.